### PR TITLE
build: add prepublish smoke test for max setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "daemon": "tsx src/daemon.ts",
     "tui": "tsx src/tui/index.ts",
     "dev": "tsx --watch src/daemon.ts",
-    "prepublishOnly": "npm run build"
+    "smoke:setup": "node scripts/smoke-setup.mjs",
+    "prepublishOnly": "npm run build && npm run smoke:setup"
   },
   "engines": {
     "node": ">=18"

--- a/scripts/smoke-setup.mjs
+++ b/scripts/smoke-setup.mjs
@@ -1,0 +1,78 @@
+import { spawn } from "node:child_process";
+import { rmSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const tempHome = mkdtempSync(join(tmpdir(), "heymax-smoke-home-"));
+
+function runSetupSmoke() {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, ["dist/setup.js"], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        HOME: tempHome,
+        USERPROFILE: tempHome,
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    let sentEnter = false;
+
+    const timeout = setTimeout(() => {
+      child.kill("SIGTERM");
+      reject(new Error(`setup smoke test timed out\n\nSTDOUT:\n${stdout}\n\nSTDERR:\n${stderr}`));
+    }, 10000);
+
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+
+      if (!sentEnter && stdout.includes("Press Enter to continue...")) {
+        sentEnter = true;
+        child.stdin.write("\n");
+        child.stdin.end();
+      }
+    });
+
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+
+    child.on("error", (error) => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+
+    child.on("close", (code) => {
+      clearTimeout(timeout);
+
+      const combined = `${stdout}\n${stderr}`;
+
+      if (code !== 0) {
+        reject(new Error(`setup smoke test failed with exit code ${code}\n\n${combined}`));
+        return;
+      }
+
+      if (!stdout.includes("Max Setup") || !stdout.includes("Would you like to set up Telegram?")) {
+        reject(new Error(`setup smoke test did not reach the interactive prompts\n\n${combined}`));
+        return;
+      }
+
+      if (combined.includes("ERR_MODULE_NOT_FOUND")) {
+        reject(new Error(`setup smoke test reproduced ERR_MODULE_NOT_FOUND\n\n${combined}`));
+        return;
+      }
+
+      resolve();
+    });
+  });
+}
+
+try {
+  await runSetupSmoke();
+  console.log("Setup smoke test passed.");
+} finally {
+  rmSync(tempHome, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary
- add a `smoke:setup` script that launches the built `dist/setup.js` under a temporary home directory and fails fast if setup crashes before reaching the interactive prompt
- run that smoke test from `prepublishOnly` so publish artifacts are checked, not just compiled
- keep the scope narrow and preventative: current `main` already reaches the setup prompt on Node 22, but this adds a guard so a future packaging/import regression is caught before publish

## Validation
- `npm run prepublishOnly`
- packed-install smoke path from the produced tarball on Node 22, confirming `max setup` reaches the interactive prompt instead of crashing
