### PR TITLE
feat: persistent specialist agent team architecture

### DIFF
--- a/agents/coder/AGENT.md
+++ b/agents/coder/AGENT.md
@@ -1,0 +1,26 @@
+---
+name: Coder
+emoji: 💻
+model: claude-sonnet-4.6
+triggers: code, programming, debug, fix, refactor, test, build, deploy, api, database, git, architecture, typescript, javascript, python, rust, go
+skills: 
+---
+
+You are a software engineering specialist. You write clean, maintainable code and think in terms of architecture, testing, and developer experience.
+
+Your expertise includes:
+- **Languages**: TypeScript/JavaScript, Python, Rust, Go, and general programming concepts
+- **Architecture**: System design, API design, database modeling, microservices, monoliths
+- **Testing**: Unit tests, integration tests, E2E tests, TDD, property-based testing
+- **DevOps**: CI/CD, Docker, deployment strategies, monitoring
+- **Code quality**: Refactoring, code review, performance optimization, security best practices
+- **Tools**: Git workflows, package managers, build systems, linters
+
+When asked to code:
+1. Understand the requirements and constraints
+2. Choose the right approach for the context (don't over-engineer)
+3. Write code that's readable and maintainable
+4. Consider error handling, edge cases, and testing
+5. Explain your architectural decisions
+
+You can create worker sessions for heavy coding tasks. Prefer doing the work over just describing it.

--- a/agents/designer/AGENT.md
+++ b/agents/designer/AGENT.md
@@ -1,0 +1,25 @@
+---
+name: Designer
+emoji: 🎨
+model: claude-opus-4.6
+triggers: design, ui, ux, css, layout, styling, visual, mockup, wireframe, frontend design, tailwind, responsive, color, typography, spacing, component design, dark mode, theme
+skills: 
+---
+
+You are a UI/UX design specialist. You think in terms of visual hierarchy, user flows, accessibility, and design systems.
+
+Your expertise includes:
+- **Visual design**: Color theory, typography, spacing, layout grids, responsive design
+- **UI patterns**: Component architecture, design tokens, dark/light themes, animation
+- **UX principles**: User flows, information architecture, accessibility (WCAG), usability heuristics
+- **CSS/Tailwind**: You can write production CSS and Tailwind utility classes
+- **Design systems**: You understand atomic design, component libraries, and design tokens
+- **Frontend frameworks**: React, Vue, Svelte component patterns from a design perspective
+
+When asked to design something:
+1. Start with the UX — what's the user trying to accomplish?
+2. Propose a visual approach with clear rationale
+3. Provide concrete implementation details (colors, spacing, components)
+4. Consider edge cases: mobile, dark mode, accessibility, internationalization
+
+Be opinionated about design. If something looks bad or has poor UX, say so. Good design is not just aesthetics — it's making things work well for the user.

--- a/agents/legal/AGENT.md
+++ b/agents/legal/AGENT.md
@@ -1,0 +1,28 @@
+---
+name: Legal
+emoji: ⚖️
+model: claude-opus-4.6
+triggers: legal, contract, license, compliance, policy, terms, privacy, GDPR, copyright, intellectual property, trademark, NDA, agreement, liability, regulation
+skills: 
+---
+
+You are a legal research and drafting specialist. You help with legal documents, compliance questions, and policy analysis.
+
+**Important disclaimer**: You provide legal information and drafting assistance, not legal advice. Always recommend consulting a qualified attorney for binding legal decisions.
+
+Your expertise includes:
+- **Contract drafting**: Terms of service, privacy policies, NDAs, service agreements, licensing
+- **Open source licensing**: MIT, Apache, GPL, Creative Commons — compatibility and implications
+- **Privacy & compliance**: GDPR, CCPA, data protection principles, cookie policies
+- **Intellectual property**: Copyright basics, trademark considerations, trade secrets
+- **Policy analysis**: Reviewing and summarizing legal documents, identifying key clauses and risks
+- **Regulatory awareness**: General understanding of tech industry regulations
+
+When asked for legal help:
+1. Identify what type of legal question this is
+2. Provide relevant legal information and context
+3. Draft or review documents with clear, plain language
+4. Flag potential risks and areas of concern
+5. Always recommend professional legal review for anything binding
+
+Write legal documents in clear, accessible language. Legalese for the sake of legalese helps no one. Every clause should be understandable by a non-lawyer.

--- a/agents/researcher/AGENT.md
+++ b/agents/researcher/AGENT.md
@@ -1,0 +1,26 @@
+---
+name: Researcher
+emoji: 🔍
+model: claude-sonnet-4.6
+triggers: research, analyze, investigate, compare, summarize, find, look up, fact check, literature, report, study, review, survey, benchmark
+skills: 
+---
+
+You are a research and analysis specialist. You gather information, synthesize findings, and present clear, well-sourced conclusions.
+
+Your expertise includes:
+- **Research methodology**: Systematic information gathering, source evaluation, bias detection
+- **Analysis**: Comparative analysis, trend analysis, cost-benefit analysis, risk assessment
+- **Synthesis**: Distilling complex topics into clear summaries, identifying key takeaways
+- **Technical research**: Library/framework evaluation, technology comparisons, best practices surveys
+- **Fact-checking**: Verifying claims, cross-referencing sources, identifying misinformation
+- **Reporting**: Structured reports, executive summaries, decision matrices
+
+When asked to research:
+1. Clarify the scope — what exactly needs to be answered?
+2. Gather information from multiple angles
+3. Evaluate source quality and potential biases
+4. Synthesize findings into a clear, actionable summary
+5. Flag uncertainties and knowledge gaps honestly
+
+Be thorough but concise. The user needs answers, not a dissertation. Always distinguish between facts and opinions.

--- a/src/agents/bus.ts
+++ b/src/agents/bus.ts
@@ -1,0 +1,463 @@
+// ---------------------------------------------------------------------------
+// AgentBus — coordination layer for persistent specialist agents
+// ---------------------------------------------------------------------------
+
+import { approveAll, type CopilotClient, type CopilotSession } from "@github/copilot-sdk";
+import { type AgentConfig, getAgent, listAgents } from "./registry.js";
+import { getAgentRelevantMemories, getAgentMemorySummary, addAgentMemory, searchAgentMemories, countAgentMemories } from "./memory.js";
+import { saveAgentSession, getAgentSession, updateAgentSessionStatus, deleteAgentSession } from "../store/db.js";
+import { config } from "../config.js";
+import { SESSIONS_DIR } from "../paths.js";
+import { z } from "zod";
+import { defineTool, type Tool } from "@github/copilot-sdk";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface AgentInstance {
+  slug: string;
+  config: AgentConfig;
+  session: CopilotSession;
+  status: "idle" | "running" | "error";
+  lastActive: number;
+  lastError?: string;
+  currentTask?: string;
+}
+
+export type AgentEventType =
+  | "agent:spawned"
+  | "agent:response"
+  | "agent:error"
+  | "agent:idle"
+  | "agent:destroyed";
+
+export type AgentEventCallback = (type: AgentEventType, slug: string, data?: string) => void;
+
+export interface ChainStep {
+  agent: string;
+  prompt: string;
+}
+
+export interface ChainOptions {
+  onProgress?: (step: ChainStep, index: number, total: number) => void;
+}
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+const agents = new Map<string, AgentInstance>();
+const agentLocks = new Map<string, Promise<void>>();
+let busClient: CopilotClient | undefined;
+let idleCheckTimer: ReturnType<typeof setInterval> | undefined;
+let eventCallback: AgentEventCallback | undefined;
+
+/** Serialize operations per agent slug to prevent spawn/dispatch/destroy races. */
+async function withAgentLock<T>(slug: string, fn: () => Promise<T>): Promise<T> {
+  const prev = agentLocks.get(slug) ?? Promise.resolve();
+  let resolve: () => void;
+  const next = new Promise<void>((r) => { resolve = r; });
+  agentLocks.set(slug, next);
+  try {
+    await prev;
+    return await fn();
+  } finally {
+    resolve!();
+    if (agentLocks.get(slug) === next) agentLocks.delete(slug);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export function setAgentEventCallback(cb: AgentEventCallback): void {
+  eventCallback = cb;
+}
+
+function emit(type: AgentEventType, slug: string, data?: string): void {
+  eventCallback?.(type, slug, data);
+}
+
+/** Initialize the bus with the SDK client. */
+export function initAgentBus(client: CopilotClient): void {
+  busClient = client;
+  startIdleCheck();
+}
+
+/** Shut down all agent sessions and stop the idle timer. */
+export async function shutdownAgentBus(): Promise<void> {
+  if (idleCheckTimer) {
+    clearInterval(idleCheckTimer);
+    idleCheckTimer = undefined;
+  }
+  await Promise.allSettled(
+    Array.from(agents.values()).map((a) => a.session.destroy().catch(() => {}))
+  );
+  agents.clear();
+}
+
+/** Get the in-memory map of active agent instances. */
+export function getAgentInstances(): Map<string, AgentInstance> {
+  return agents;
+}
+
+// ---------------------------------------------------------------------------
+// Agent Tools — memory tools scoped to the agent's namespace
+// ---------------------------------------------------------------------------
+
+function createAgentTools(agentSlug: string): Tool<any>[] {
+  return [
+    defineTool("remember", {
+      description:
+        "Save something to your long-term memory. Use when the user says 'remember that...', " +
+        "states a preference, or shares important information about your domain.",
+      parameters: z.object({
+        category: z.enum(["preference", "fact", "project", "person", "routine"])
+          .describe("Category of the memory"),
+        content: z.string().describe("The thing to remember"),
+        source: z.enum(["user", "auto"]).optional().describe("'user' if explicitly asked, 'auto' if detected"),
+      }),
+      handler: async (args) => {
+        const id = addAgentMemory(agentSlug, args.category, args.content, args.source || "user");
+        return `Remembered (#${id}, ${args.category}): "${args.content}"`;
+      },
+    }),
+
+    defineTool("recall", {
+      description:
+        "Search your long-term memory for stored facts, preferences, or information.",
+      parameters: z.object({
+        keyword: z.string().optional().describe("Search term"),
+        category: z.enum(["preference", "fact", "project", "person", "routine"]).optional(),
+      }),
+      handler: async (args) => {
+        const results = searchAgentMemories(agentSlug, args.keyword, args.category);
+        if (results.length === 0) return "No matching memories found.";
+        const lines = results.map(
+          (m) => `• #${m.id} [${m.category}] ${m.content} (${m.source}, ${m.created_at})`
+        );
+        return `Found ${results.length} memory/memories:\n${lines.join("\n")}`;
+      },
+    }),
+
+    defineTool("request_context", {
+      description:
+        "Request cross-domain context from Max when you don't have the information you need. " +
+        "Max can check other specialists' memories or answer your question directly.",
+      parameters: z.object({
+        question: z.string().describe("What you need to know — be specific"),
+      }),
+      handler: async (args) => {
+        // This is a signal to the orchestrator — the response will be injected by Max
+        return `[Context request from ${agentSlug}]: ${args.question}\n\n(Max will provide the context you need.)`;
+      },
+    }),
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Spawn / Resume
+// ---------------------------------------------------------------------------
+
+async function ensureClient(): Promise<CopilotClient> {
+  if (!busClient) throw new Error("AgentBus not initialized — call initAgentBus() first");
+  return busClient;
+}
+
+/** Spawn or resume a specialist agent session. */
+async function spawnAgent(agentConfig: AgentConfig): Promise<AgentInstance> {
+  if (agents.size >= config.maxConcurrentAgents) {
+    // Evict the least recently used idle agent
+    let oldestIdle: AgentInstance | undefined;
+    for (const inst of agents.values()) {
+      if (inst.status === "idle" && (!oldestIdle || inst.lastActive < oldestIdle.lastActive)) {
+        oldestIdle = inst;
+      }
+    }
+    if (oldestIdle) {
+      console.log(`[max] Agent limit reached, evicting idle agent '${oldestIdle.slug}'`);
+      await destroyAgent(oldestIdle.slug);
+    } else {
+      throw new Error(`Agent limit reached (${config.maxConcurrentAgents}). No idle agents to evict.`);
+    }
+  }
+
+  const client = await ensureClient();
+  const model = agentConfig.model || config.copilotModel;
+  const memorySummary = getAgentMemorySummary(agentConfig.slug);
+
+  const systemMessage = buildAgentSystemMessage(agentConfig, memorySummary);
+  const tools = createAgentTools(agentConfig.slug);
+
+  const infiniteSessions = {
+    enabled: true,
+    backgroundCompactionThreshold: 0.80,
+    bufferExhaustionThreshold: 0.95,
+  };
+
+  // Try to resume a saved session
+  const saved = getAgentSession(agentConfig.slug);
+  let session: CopilotSession | undefined;
+
+  if (saved) {
+    try {
+      console.log(`[max] Resuming agent '${agentConfig.slug}' session ${saved.copilot_session_id.slice(0, 8)}…`);
+      session = await client.resumeSession(saved.copilot_session_id, {
+        model,
+        configDir: SESSIONS_DIR,
+        streaming: false,
+        systemMessage: { content: systemMessage },
+        tools,
+        onPermissionRequest: approveAll,
+        infiniteSessions,
+      });
+      console.log(`[max] Resumed agent '${agentConfig.slug}' successfully`);
+    } catch (err) {
+      console.log(`[max] Could not resume agent '${agentConfig.slug}': ${err instanceof Error ? err.message : err}. Creating new.`);
+      deleteAgentSession(agentConfig.slug);
+      session = undefined;
+    }
+  }
+
+  if (!session) {
+    console.log(`[max] Creating new session for agent '${agentConfig.slug}'`);
+    session = await client.createSession({
+      model,
+      configDir: SESSIONS_DIR,
+      streaming: false,
+      systemMessage: { content: systemMessage },
+      tools,
+      onPermissionRequest: approveAll,
+      infiniteSessions,
+    });
+    saveAgentSession(agentConfig.slug, session.sessionId, model);
+    console.log(`[max] Agent '${agentConfig.slug}' session created: ${session.sessionId.slice(0, 8)}…`);
+  }
+
+  const instance: AgentInstance = {
+    slug: agentConfig.slug,
+    config: agentConfig,
+    session,
+    status: "idle",
+    lastActive: Date.now(),
+  };
+
+  agents.set(agentConfig.slug, instance);
+  emit("agent:spawned", agentConfig.slug);
+  return instance;
+}
+
+function buildAgentSystemMessage(agentConfig: AgentConfig, memorySummary: string): string {
+  const memoryBlock = memorySummary
+    ? `\n## Your Long-Term Memory\n${memorySummary}\n`
+    : "";
+
+  return `You are ${agentConfig.name}, a specialist agent working as part of Max's team. ${agentConfig.systemPrompt}
+
+## How You Work
+
+You are a persistent specialist agent. Your conversation history is maintained across tasks. You have your own memory namespace — use the \`remember\` and \`recall\` tools to save and retrieve domain-specific information.
+
+If you need information outside your domain, use the \`request_context\` tool to ask Max for help. He can check other specialists or answer directly.
+
+Keep your responses focused on your domain of expertise. Be concise and actionable.
+${memoryBlock}`;
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch
+// ---------------------------------------------------------------------------
+
+/**
+ * Dispatch a prompt to a specialist agent. Spawns the agent if needed.
+ * Returns the agent's response text.
+ */
+export async function dispatch(
+  agentSlug: string,
+  prompt: string,
+  timeoutMs = 300_000
+): Promise<string> {
+  const agentConfig = getAgent(agentSlug);
+  if (!agentConfig) {
+    return `No agent defined with slug '${agentSlug}'. Available: ${listAgents().map((a) => a.slug).join(", ")}`;
+  }
+
+  return withAgentLock(agentSlug, async () => {
+    let instance = agents.get(agentSlug);
+    if (!instance) {
+      instance = await spawnAgent(agentConfig);
+    }
+
+    instance.status = "running";
+    instance.lastActive = Date.now();
+    instance.currentTask = prompt.slice(0, 200);
+    updateAgentSessionStatus(agentSlug, "running");
+
+    // Inject relevant memories
+    let enrichedPrompt = prompt;
+    try {
+      const relevant = getAgentRelevantMemories(agentSlug, prompt, 5);
+      if (relevant.length > 0) {
+        const memBlock = relevant.join("; ");
+        const trimmed = memBlock.length > 500 ? memBlock.slice(0, 500) + "…" : memBlock;
+        enrichedPrompt = `[Memory context: ${trimmed}]\n\n${prompt}`;
+      }
+    } catch { /* non-fatal */ }
+
+    try {
+      const result = await instance.session.sendAndWait({ prompt: enrichedPrompt }, timeoutMs);
+      const content = result?.data?.content || "(No response)";
+      instance.status = "idle";
+      instance.lastActive = Date.now();
+      instance.currentTask = undefined;
+      instance.lastError = undefined;
+      updateAgentSessionStatus(agentSlug, "idle");
+      emit("agent:response", agentSlug, content);
+      return content;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      instance.status = "error";
+      instance.lastError = msg;
+      instance.currentTask = undefined;
+      updateAgentSessionStatus(agentSlug, "error");
+      emit("agent:error", agentSlug, msg);
+
+      // If session is broken, invalidate for recreation
+      if (/closed|destroy|disposed|invalid|expired|not found/i.test(msg)) {
+        console.log(`[max] Agent '${agentSlug}' session appears dead, will recreate: ${msg}`);
+        agents.delete(agentSlug);
+        deleteAgentSession(agentSlug);
+      }
+
+      throw err;
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Chaining
+// ---------------------------------------------------------------------------
+
+/**
+ * Execute a chain of agent steps sequentially.
+ * Each step's output is available to the next step via {{prev}}.
+ */
+export async function chain(
+  steps: ChainStep[],
+  options?: ChainOptions,
+): Promise<string> {
+  let previousOutput = "";
+
+  for (let i = 0; i < steps.length; i++) {
+    const step = steps[i];
+    options?.onProgress?.(step, i, steps.length);
+
+    // Replace {{prev}} placeholder with previous output
+    const prompt = step.prompt.replace(/\{\{prev\}\}/g, previousOutput);
+
+    try {
+      previousOutput = await dispatch(step.agent, prompt);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.log(`[max] Chain step ${i + 1}/${steps.length} failed (agent: ${step.agent}): ${msg}`);
+
+      // Try recovery: retry once
+      try {
+        previousOutput = await dispatch(step.agent, prompt);
+      } catch (retryErr) {
+        const retryMsg = retryErr instanceof Error ? retryErr.message : String(retryErr);
+        // Skip this step, pass error context forward
+        previousOutput = `[Error from ${step.agent}: ${retryMsg}. Previous context: ${previousOutput}]`;
+      }
+    }
+  }
+
+  return previousOutput;
+}
+
+// ---------------------------------------------------------------------------
+// Status & Management
+// ---------------------------------------------------------------------------
+
+export interface AgentStatus {
+  slug: string;
+  name: string;
+  emoji: string;
+  status: "idle" | "running" | "error" | "not_spawned";
+  lastActive?: number;
+  currentTask?: string;
+  lastError?: string;
+  memoryCount: number;
+}
+
+export function getAgentStatus(slug: string): AgentStatus {
+  const agentConfig = getAgent(slug);
+  if (!agentConfig) {
+    return { slug, name: slug, emoji: "❓", status: "not_spawned", memoryCount: 0 };
+  }
+
+  const instance = agents.get(slug);
+  if (!instance) {
+    return {
+      slug,
+      name: agentConfig.name,
+      emoji: agentConfig.emoji,
+      status: "not_spawned",
+      memoryCount: countAgentMemories(slug),
+    };
+  }
+
+  return {
+    slug,
+    name: instance.config.name,
+    emoji: instance.config.emoji,
+    status: instance.status,
+    lastActive: instance.lastActive,
+    currentTask: instance.currentTask,
+    lastError: instance.lastError,
+    memoryCount: countAgentMemories(slug),
+  };
+}
+
+export function getAllAgentStatuses(): AgentStatus[] {
+  return listAgents().map((a) => getAgentStatus(a.slug));
+}
+
+/** Destroy a specific agent session. */
+export async function destroyAgent(slug: string): Promise<void> {
+  return withAgentLock(slug, async () => {
+    const instance = agents.get(slug);
+    if (instance) {
+      // Remove from map first to prevent dispatch picking up a dying session
+      agents.delete(slug);
+      deleteAgentSession(slug);
+      try { await instance.session.destroy(); } catch { /* best-effort */ }
+      emit("agent:destroyed", slug);
+      console.log(`[max] Agent '${slug}' destroyed`);
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Idle Cleanup
+// ---------------------------------------------------------------------------
+
+function startIdleCheck(): void {
+  if (idleCheckTimer) return;
+  // Check every 5 minutes
+  idleCheckTimer = setInterval(() => {
+    const now = Date.now();
+    const timeout = config.agentIdleTimeoutMs;
+    for (const [slug, instance] of agents) {
+      if (instance.status === "idle" && (now - instance.lastActive) > timeout) {
+        console.log(`[max] Agent '${slug}' idle for >${Math.round(timeout / 60_000)}min, destroying`);
+        destroyAgent(slug).catch((err) => {
+          console.error(`[max] Failed to destroy idle agent '${slug}':`, err instanceof Error ? err.message : err);
+        });
+        emit("agent:idle", slug);
+      }
+    }
+  }, 300_000);
+}

--- a/src/agents/memory.ts
+++ b/src/agents/memory.ts
@@ -1,0 +1,141 @@
+// ---------------------------------------------------------------------------
+// Namespace-scoped memory — wraps db.ts memory functions with namespace
+// ---------------------------------------------------------------------------
+
+import { getDb, addMemory, searchMemories, removeMemory, getRelevantMemories } from "../store/db.js";
+
+/**
+ * Add a memory to a specific agent's namespace.
+ * Falls back to "global" (Max's namespace) when no namespace specified.
+ */
+export function addAgentMemory(
+  namespace: string,
+  category: "preference" | "fact" | "project" | "person" | "routine",
+  content: string,
+  source: "user" | "auto" = "user"
+): number {
+  const db = getDb();
+  const result = db.prepare(
+    `INSERT INTO memories (category, content, source, namespace) VALUES (?, ?, ?, ?)`
+  ).run(category, content, source, namespace);
+  return result.lastInsertRowid as number;
+}
+
+/**
+ * Search memories within a specific namespace.
+ * Optionally include the "global" namespace for shared context.
+ */
+export function searchAgentMemories(
+  namespace: string,
+  keyword?: string,
+  category?: string,
+  limit = 20,
+  includeGlobal = false,
+): { id: number; category: string; content: string; source: string; namespace: string; created_at: string }[] {
+  const db = getDb();
+  const namespaces = includeGlobal && namespace !== "global"
+    ? [namespace, "global"]
+    : [namespace];
+  const nsPlaceholders = namespaces.map(() => "?").join(",");
+
+  const conditions: string[] = [`namespace IN (${nsPlaceholders})`];
+  const params: (string | number)[] = [...namespaces];
+
+  if (keyword) {
+    const escapedKeyword = keyword.replace(/[%_\\]/g, "\\$&");
+    conditions.push(`content LIKE ? ESCAPE '\\'`);
+    params.push(`%${escapedKeyword}%`);
+  }
+  if (category) {
+    conditions.push(`category = ?`);
+    params.push(category);
+  }
+
+  const where = `WHERE ${conditions.join(" AND ")}`;
+  params.push(limit);
+
+  return db.prepare(
+    `SELECT id, category, content, source, namespace, created_at FROM memories ${where} ORDER BY last_accessed DESC LIMIT ?`
+  ).all(...params) as { id: number; category: string; content: string; source: string; namespace: string; created_at: string }[];
+}
+
+/**
+ * Get relevant memories for a query, scoped to a namespace.
+ */
+export function getAgentRelevantMemories(namespace: string, query: string, limit = 5): string[] {
+  const db = getDb();
+  const cleanQuery = query.replace(/^\[via (?:telegram|tui)\]\s*/i, "").trim();
+  const queryWords = new Set(
+    cleanQuery.toLowerCase().split(/\s+/).filter((w) => w.length > 3)
+  );
+
+  if (queryWords.size === 0) {
+    const rows = db.prepare(
+      `SELECT content FROM memories WHERE namespace = ? ORDER BY last_accessed DESC LIMIT ?`
+    ).all(namespace, Math.min(limit, 3)) as { content: string }[];
+    return rows.map((r) => r.content);
+  }
+
+  // Word overlap search within namespace
+  const rows = db.prepare(
+    `SELECT id, content FROM memories WHERE namespace = ? ORDER BY last_accessed DESC`
+  ).all(namespace) as { id: number; content: string }[];
+
+  const scored = rows.map((row) => {
+    const memWords = row.content.toLowerCase().split(/\s+/);
+    let hits = 0;
+    for (const w of memWords) {
+      if (queryWords.has(w)) hits++;
+    }
+    return { ...row, hits };
+  }).filter((r) => r.hits >= 2)
+    .sort((a, b) => b.hits - a.hits)
+    .slice(0, limit);
+
+  if (scored.length === 0) {
+    const recent = db.prepare(
+      `SELECT content FROM memories WHERE namespace = ? ORDER BY last_accessed DESC LIMIT ?`
+    ).all(namespace, Math.min(limit, 3)) as { content: string }[];
+    return recent.map((r) => r.content);
+  }
+
+  if (scored.length > 0) {
+    const placeholders = scored.map(() => "?").join(",");
+    db.prepare(`UPDATE memories SET last_accessed = CURRENT_TIMESTAMP WHERE id IN (${placeholders})`).run(...scored.map((r) => r.id));
+  }
+
+  return scored.map((r) => r.content);
+}
+
+/**
+ * Get a compact memory summary for an agent's namespace.
+ */
+export function getAgentMemorySummary(namespace: string): string {
+  const db = getDb();
+  const rows = db.prepare(
+    `SELECT id, category, content FROM memories WHERE namespace = ? ORDER BY category, last_accessed DESC`
+  ).all(namespace) as { id: number; category: string; content: string }[];
+
+  if (rows.length === 0) return "";
+
+  const grouped: Record<string, { id: number; content: string }[]> = {};
+  for (const r of rows) {
+    if (!grouped[r.category]) grouped[r.category] = [];
+    grouped[r.category].push({ id: r.id, content: r.content });
+  }
+
+  const sections = Object.entries(grouped).map(([cat, items]) => {
+    const lines = items.map((i) => `  - [#${i.id}] ${i.content}`).join("\n");
+    return `**${cat}**:\n${lines}`;
+  });
+
+  return sections.join("\n");
+}
+
+/**
+ * Count memories in a namespace.
+ */
+export function countAgentMemories(namespace: string): number {
+  const db = getDb();
+  return (db.prepare(`SELECT COUNT(*) as c FROM memories WHERE namespace = ?`).get(namespace) as { c: number }).c;
+}

--- a/src/agents/mentions.ts
+++ b/src/agents/mentions.ts
@@ -1,0 +1,76 @@
+// ---------------------------------------------------------------------------
+// @mention parser + sticky session state
+// ---------------------------------------------------------------------------
+
+import { listAgents } from "./registry.js";
+
+export interface MentionResult {
+  /** The agent slug extracted from the mention, or undefined if none. */
+  agent?: string;
+  /** Whether this is a @max mention (return to orchestrator). */
+  isMaxMention: boolean;
+  /** The prompt text with the @mention stripped. */
+  text: string;
+}
+
+/** Known agent slugs, refreshed from the registry. */
+function getKnownSlugs(): Set<string> {
+  return new Set(listAgents().map((a) => a.slug));
+}
+
+/**
+ * Parse an @mention from the beginning of a message.
+ * Returns the agent slug and stripped text.
+ */
+export function parseMention(text: string): MentionResult {
+  // Strip channel tags first
+  const cleaned = text.replace(/^\[via (?:telegram|tui)\]\s*/i, "");
+  const match = cleaned.match(/^@([\w-]+)\s*([\s\S]*)/);
+
+  if (!match) {
+    return { isMaxMention: false, text: cleaned };
+  }
+
+  const mentioned = match[1].toLowerCase();
+  const remainder = match[2].trim();
+
+  // @max → return to orchestrator
+  if (mentioned === "max") {
+    return { isMaxMention: true, text: remainder || cleaned };
+  }
+
+  // Check if the mentioned name is a known agent
+  const known = getKnownSlugs();
+  if (known.has(mentioned)) {
+    return { agent: mentioned, isMaxMention: false, text: remainder || cleaned };
+  }
+
+  // Unknown @mention — leave the message as-is
+  return { isMaxMention: false, text: cleaned };
+}
+
+// ---------------------------------------------------------------------------
+// Sticky session state (per-channel, in-memory, resets on restart)
+// ---------------------------------------------------------------------------
+
+const stickyAgents = new Map<string, string>();
+
+/** Get the sticky agent for a channel. */
+export function getStickyAgent(channel: string): string | undefined {
+  return stickyAgents.get(channel);
+}
+
+/** Set a sticky agent for a channel. */
+export function setStickyAgent(channel: string, agentSlug: string): void {
+  stickyAgents.set(channel, agentSlug);
+}
+
+/** Clear the sticky agent for a channel (return to Max). */
+export function clearStickyAgent(channel: string): void {
+  stickyAgents.delete(channel);
+}
+
+/** Get all sticky sessions (for debugging / /agent command). */
+export function getAllStickyAgents(): Map<string, string> {
+  return new Map(stickyAgents);
+}

--- a/src/agents/registry.ts
+++ b/src/agents/registry.ts
@@ -1,0 +1,177 @@
+import { readdirSync, readFileSync, existsSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+import { AGENTS_DIR } from "../paths.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface AgentConfig {
+  slug: string;
+  name: string;
+  emoji: string;
+  model: string;
+  triggers: string[];
+  skills: string[];
+  systemPrompt: string;
+  source: "builtin" | "user";
+}
+
+// ---------------------------------------------------------------------------
+// Directories
+// ---------------------------------------------------------------------------
+
+/** User-local agents directory (~/.max/agents/) */
+const USER_AGENTS_DIR = AGENTS_DIR;
+
+/** Agents bundled with the Max package */
+const BUNDLED_AGENTS_DIR = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "agents"
+);
+
+// ---------------------------------------------------------------------------
+// Frontmatter parser (reuses the SKILL.md pattern)
+// ---------------------------------------------------------------------------
+
+interface AgentFrontmatter {
+  name: string;
+  emoji: string;
+  model: string;
+  triggers: string[];
+  skills: string[];
+}
+
+function parseFrontmatter(content: string): { frontmatter: AgentFrontmatter; body: string } {
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) {
+    return {
+      frontmatter: { name: "", emoji: "", model: "", triggers: [], skills: [] },
+      body: content.trim(),
+    };
+  }
+
+  const raw = match[1];
+  const body = content.slice(match[0].length).trim();
+
+  let name = "";
+  let emoji = "";
+  let model = "";
+  let triggers: string[] = [];
+  let skills: string[] = [];
+
+  for (const line of raw.split("\n")) {
+    const idx = line.indexOf(": ");
+    if (idx <= 0) continue;
+    const key = line.slice(0, idx).trim();
+    const value = line.slice(idx + 2).trim();
+    switch (key) {
+      case "name": name = value; break;
+      case "emoji": emoji = value; break;
+      case "model": model = value; break;
+      case "triggers":
+        triggers = value.split(",").map((t) => t.trim()).filter(Boolean);
+        break;
+      case "skills":
+        skills = value.split(",").map((s) => s.trim()).filter(Boolean);
+        break;
+    }
+  }
+
+  return { frontmatter: { name, emoji, model, triggers, skills }, body };
+}
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
+
+let agentCache: Map<string, AgentConfig> | undefined;
+
+function scanDirectory(dir: string, source: "builtin" | "user"): AgentConfig[] {
+  if (!existsSync(dir)) return [];
+
+  const agents: AgentConfig[] = [];
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return [];
+  }
+
+  for (const entry of entries) {
+    const agentDir = join(dir, entry);
+    const agentMd = join(agentDir, "AGENT.md");
+    if (!existsSync(agentMd)) continue;
+
+    try {
+      const content = readFileSync(agentMd, "utf-8");
+      const { frontmatter, body } = parseFrontmatter(content);
+      agents.push({
+        slug: entry,
+        name: frontmatter.name || entry,
+        emoji: frontmatter.emoji || "🤖",
+        model: frontmatter.model || "",
+        triggers: frontmatter.triggers,
+        skills: frontmatter.skills,
+        systemPrompt: body,
+        source,
+      });
+    } catch {
+      console.log(`[max] Could not parse agent config: ${agentMd}`);
+    }
+  }
+
+  return agents;
+}
+
+/** Load all agent configs from disk. User agents override bundled agents with the same slug. */
+export function loadAgents(): Map<string, AgentConfig> {
+  const map = new Map<string, AgentConfig>();
+
+  // Bundled agents first
+  for (const agent of scanDirectory(BUNDLED_AGENTS_DIR, "builtin")) {
+    map.set(agent.slug, agent);
+  }
+
+  // User agents override
+  for (const agent of scanDirectory(USER_AGENTS_DIR, "user")) {
+    map.set(agent.slug, agent);
+  }
+
+  agentCache = map;
+  return map;
+}
+
+/** Get a specific agent by slug. Lazy-loads if not yet scanned. */
+export function getAgent(slug: string): AgentConfig | undefined {
+  if (!agentCache) loadAgents();
+  return agentCache!.get(slug);
+}
+
+/** List all available agents. Lazy-loads if not yet scanned. */
+export function listAgents(): AgentConfig[] {
+  if (!agentCache) loadAgents();
+  return Array.from(agentCache!.values());
+}
+
+/** Re-scan agent directories (e.g. after restart or /reload). */
+export function reloadAgents(): Map<string, AgentConfig> {
+  agentCache = undefined;
+  return loadAgents();
+}
+
+/** Build a summary of available agents for injection into system prompts. */
+export function getAgentSummary(): string {
+  const agents = listAgents();
+  if (agents.length === 0) return "";
+
+  const lines = agents.map((a) => {
+    const triggers = a.triggers.length > 0 ? ` (triggers: ${a.triggers.join(", ")})` : "";
+    return `- ${a.emoji} **${a.name}** (\`@${a.slug}\`): ${a.systemPrompt.slice(0, 150).replace(/\n/g, " ")}…${triggers}`;
+  });
+
+  return lines.join("\n");
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,6 +13,8 @@ const configSchema = z.object({
   API_PORT: z.string().optional(),
   COPILOT_MODEL: z.string().optional(),
   WORKER_TIMEOUT: z.string().optional(),
+  MAX_CONCURRENT_AGENTS: z.string().optional(),
+  AGENT_IDLE_TIMEOUT: z.string().optional(),
 });
 
 const raw = configSchema.parse(process.env);
@@ -38,6 +40,24 @@ if (!Number.isInteger(parsedWorkerTimeout) || parsedWorkerTimeout <= 0) {
   throw new Error(`WORKER_TIMEOUT must be a positive integer (ms), got: "${raw.WORKER_TIMEOUT}"`);
 }
 
+const DEFAULT_MAX_CONCURRENT_AGENTS = 5;
+const parsedMaxAgents = raw.MAX_CONCURRENT_AGENTS
+  ? Number(raw.MAX_CONCURRENT_AGENTS)
+  : DEFAULT_MAX_CONCURRENT_AGENTS;
+
+if (!Number.isInteger(parsedMaxAgents) || parsedMaxAgents < 1) {
+  throw new Error(`MAX_CONCURRENT_AGENTS must be a positive integer, got: "${raw.MAX_CONCURRENT_AGENTS}"`);
+}
+
+const DEFAULT_AGENT_IDLE_TIMEOUT_MS = 3_600_000; // 60 minutes
+const parsedAgentIdleTimeout = raw.AGENT_IDLE_TIMEOUT
+  ? Number(raw.AGENT_IDLE_TIMEOUT)
+  : DEFAULT_AGENT_IDLE_TIMEOUT_MS;
+
+if (!Number.isInteger(parsedAgentIdleTimeout) || parsedAgentIdleTimeout < 60_000) {
+  throw new Error(`AGENT_IDLE_TIMEOUT must be an integer ≥ 60000 (ms), got: "${raw.AGENT_IDLE_TIMEOUT}"`);
+}
+
 export const DEFAULT_MODEL = "claude-sonnet-4.6";
 
 let _copilotModel = raw.COPILOT_MODEL || DEFAULT_MODEL;
@@ -47,6 +67,8 @@ export const config = {
   authorizedUserId: parsedUserId,
   apiPort: parsedPort,
   workerTimeoutMs: parsedWorkerTimeout,
+  maxConcurrentAgents: parsedMaxAgents,
+  agentIdleTimeoutMs: parsedAgentIdleTimeout,
   get copilotModel(): string {
     return _copilotModel;
   },

--- a/src/copilot/orchestrator.ts
+++ b/src/copilot/orchestrator.ts
@@ -9,6 +9,9 @@ import { logConversation, getState, setState, deleteState, getMemorySummary, get
 import { SESSIONS_DIR } from "../paths.js";
 import { resolveModel, type Tier, type RouteResult } from "./router.js";
 import { extractAndSaveMemories } from "./memory-extractor.js";
+import { parseMention, getStickyAgent, setStickyAgent, clearStickyAgent } from "../agents/mentions.js";
+import { dispatch as agentDispatch } from "../agents/bus.js";
+import { getAgent } from "../agents/registry.js";
 
 const MAX_RETRIES = 3;
 const RECONNECT_DELAYS_MS = [1_000, 3_000, 10_000];
@@ -413,6 +416,57 @@ export async function sendToOrchestrator(
     source.type === "tui" ? "tui" : "background";
   logMessage("in", sourceLabel, prompt);
 
+  // --- @mention pre-routing ---
+  // For non-background messages, check for @agent mentions or sticky sessions
+  if (source.type !== "background") {
+    const mention = parseMention(prompt);
+    const channel = sourceLabel;
+
+    if (mention.isMaxMention) {
+      // @max → clear sticky, route to orchestrator
+      clearStickyAgent(channel);
+    } else if (mention.agent) {
+      // @agent → set sticky, route directly to specialist
+      setStickyAgent(channel, mention.agent);
+      const agentConfig = getAgent(mention.agent);
+      const prefix = agentConfig ? `${agentConfig.emoji} **${agentConfig.name}**: ` : "";
+      callback("", false); // signal start
+      try {
+        const response = await agentDispatch(mention.agent, mention.text);
+        const attributed = `${prefix}${response}`;
+        callback(attributed, true);
+        try { logMessage("out", sourceLabel, attributed); } catch { /* best-effort */ }
+        try { logConversation("user", prompt, sourceLabel); } catch { /* best-effort */ }
+        try { logConversation("assistant", attributed, sourceLabel); } catch { /* best-effort */ }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        callback(`Error from @${mention.agent}: ${msg}`, true);
+      }
+      return;
+    } else {
+      // No explicit mention — check sticky session
+      const sticky = getStickyAgent(channel);
+      if (sticky) {
+        const agentConfig = getAgent(sticky);
+        const prefix = agentConfig ? `${agentConfig.emoji} **${agentConfig.name}**: ` : "";
+        callback("", false);
+        try {
+          const response = await agentDispatch(sticky, mention.text);
+          const attributed = `${prefix}${response}`;
+          callback(attributed, true);
+          try { logMessage("out", sourceLabel, attributed); } catch { /* best-effort */ }
+          try { logConversation("user", prompt, sourceLabel); } catch { /* best-effort */ }
+          try { logConversation("assistant", attributed, sourceLabel); } catch { /* best-effort */ }
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          callback(`Error from @${sticky}: ${msg}`, true);
+        }
+        return;
+      }
+    }
+  }
+
+  // --- Standard orchestrator flow ---
   // Tag the prompt with its source channel
   const taggedPrompt = source.type === "background"
     ? prompt

--- a/src/copilot/system-message.ts
+++ b/src/copilot/system-message.ts
@@ -1,3 +1,5 @@
+import { getAgentSummary } from "../agents/registry.js";
+
 export function getOrchestratorSystemMessage(memorySummary?: string, opts?: { selfEditEnabled?: boolean }): string {
   const memoryBlock = memorySummary
     ? `\n## Long-Term Memory\nThese are things you've been asked to remember or have noted as important:\n\n${memorySummary}\n`
@@ -135,5 +137,26 @@ Always prefer finding an existing skill over building one from scratch. The skil
 13. **You have persistent memory.** Your conversation is maintained in a single long-running session with automatic compaction — you naturally remember what was discussed. For important facts that should survive even a session reset, use the \`remember\` tool to save them to long-term memory.
 14. **Proactive memory**: When the user shares preferences, project details, people info, or routines, proactively use \`remember\` (with source "auto") so you don't forget. Don't ask for permission — just save it.
 15. **Sending media to Telegram**: You can send photos/images to the user on Telegram by calling: \`curl -s -X POST http://127.0.0.1:7777/send-photo -H 'Content-Type: application/json' -H 'Authorization: Bearer $(cat ~/.max/api-token)' -d '{"photo": "<tmpdir-path-or-https-url>", "caption": "<optional caption>"}'\`. Local file paths **must** be inside the system temp directory (use \`$TMPDIR\` or \`/tmp\`). Download images to a temp path first, then send. HTTPS URLs are also accepted.
+
+## Specialist Agent Team
+
+You have a team of persistent specialist agents. Each has domain expertise, their own memory, and a preferred model. Use \`delegate_to_agent\` to route tasks to the right specialist, and \`chain_agents\` for multi-step workflows.
+
+### Available Specialists
+${getAgentSummary() || "(No specialists configured yet.)"}
+
+### When to Delegate vs Handle Directly
+- **Delegate**: When a task clearly falls within a specialist's domain (design, coding, research, legal). The specialist has better context and memory for their area.
+- **Handle directly**: General questions, status checks, simple chat, meta-commands, or tasks that don't match any specialist.
+- **Chain**: When a task needs multiple specialists in sequence (e.g. "have legal draft terms, then designer format them").
+
+### How Delegation Works
+1. When the user sends a message with \`@agent\` (e.g. \`@designer\`), route it directly to that specialist.
+2. When a message clearly matches a specialist's domain (based on their triggers), delegate it.
+3. The specialist's response will be prefixed with their emoji and name for attribution.
+4. You can check on specialists with \`check_agent_status\`.
+
+### Agent Memory
+Each specialist has its own isolated memory namespace. When you delegate to a specialist, their memories are scoped to their domain. If a specialist needs cross-domain context, they'll use \`request_context\` and you can help by checking the relevant namespace.
 ${selfEditBlock}${memoryBlock}`;
 }

--- a/src/copilot/tools.ts
+++ b/src/copilot/tools.ts
@@ -9,6 +9,8 @@ import { config, persistModel } from "../config.js";
 import { SESSIONS_DIR } from "../paths.js";
 import { getCurrentSourceChannel, switchSessionModel } from "./orchestrator.js";
 import { getRouterConfig, updateRouterConfig } from "./router.js";
+import { dispatch, chain, getAgentStatus, getAllAgentStatuses, type ChainStep } from "../agents/bus.js";
+import { listAgents } from "../agents/registry.js";
 
 function isTimeoutError(err: unknown): boolean {
   const msg = err instanceof Error ? err.message : String(err);
@@ -534,6 +536,81 @@ export function createTools(deps: ToolDeps): Tool<any>[] {
         return removed
           ? `Memory #${args.memory_id} forgotten.`
           : `Memory #${args.memory_id} not found — it may have already been removed.`;
+      },
+    }),
+
+    defineTool("delegate_to_agent", {
+      description:
+        "Delegate a task to a specialist agent. The agent will process the prompt and return a response. " +
+        "Available specialists: " + listAgents().map((a) => `${a.emoji} ${a.name} (@${a.slug})`).join(", ") + ". " +
+        "Use when a message matches a specialist's domain. The specialist has its own persistent " +
+        "memory, system prompt, and preferred model. Returns the specialist's response.",
+      parameters: z.object({
+        agent: z.string().describe("The agent slug (e.g. 'designer', 'coder', 'researcher', 'legal')"),
+        prompt: z.string().describe("The prompt to send to the specialist"),
+      }),
+      handler: async (args) => {
+        try {
+          const response = await dispatch(args.agent, args.prompt);
+          const agentConfig = listAgents().find((a) => a.slug === args.agent);
+          const prefix = agentConfig ? `${agentConfig.emoji} **${agentConfig.name}**: ` : "";
+          return `${prefix}${response}`;
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          return `Agent '${args.agent}' failed: ${msg}`;
+        }
+      },
+    }),
+
+    defineTool("chain_agents", {
+      description:
+        "Execute a multi-step pipeline across specialist agents. Each step's output is passed " +
+        "to the next step via the {{prev}} placeholder in the prompt. Use for workflows that " +
+        "require multiple specialists (e.g. Legal drafts → Designer formats).",
+      parameters: z.object({
+        steps: z.array(z.object({
+          agent: z.string().describe("Agent slug for this step"),
+          prompt: z.string().describe("Prompt for this step. Use {{prev}} to reference the previous step's output."),
+        })).min(2).describe("Ordered list of agent steps to execute"),
+      }),
+      handler: async (args) => {
+        try {
+          const result = await chain(args.steps as ChainStep[]);
+          return result;
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          return `Chain failed: ${msg}`;
+        }
+      },
+    }),
+
+    defineTool("check_agent_status", {
+      description:
+        "Check the status of specialist agents. Shows session state (running/idle/error/not_spawned), " +
+        "last activity, current task, errors, and memory count. Use when monitoring agent health " +
+        "or when the user asks about agent status. Pass a specific agent slug or omit for all agents.",
+      parameters: z.object({
+        agent: z.string().optional().describe("Specific agent slug, or omit for all agents"),
+      }),
+      handler: async (args) => {
+        if (args.agent) {
+          const status = getAgentStatus(args.agent);
+          const age = status.lastActive
+            ? `${Math.round((Date.now() - status.lastActive) / 60_000)}min ago`
+            : "never";
+          const task = status.currentTask ? `\nCurrent task: ${status.currentTask}` : "";
+          const error = status.lastError ? `\nLast error: ${status.lastError}` : "";
+          return `${status.emoji} ${status.name}: ${status.status} (last active: ${age}, memories: ${status.memoryCount})${task}${error}`;
+        }
+        const statuses = getAllAgentStatuses();
+        if (statuses.length === 0) return "No specialist agents configured.";
+        const lines = statuses.map((s) => {
+          const age = s.lastActive
+            ? `${Math.round((Date.now() - s.lastActive) / 60_000)}min ago`
+            : "—";
+          return `${s.emoji} ${s.name} (@${s.slug}): ${s.status} | last: ${age} | memories: ${s.memoryCount}`;
+        });
+        return `Specialist agents:\n${lines.join("\n")}`;
       },
     }),
 

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -6,6 +6,8 @@ import { getDb, closeDb } from "./store/db.js";
 import { config } from "./config.js";
 import { spawn } from "child_process";
 import { checkForUpdate } from "./update.js";
+import { initAgentBus, shutdownAgentBus } from "./agents/bus.js";
+import { loadAgents } from "./agents/registry.js";
 
 function truncate(text: string, max = 200): string {
   const oneLine = text.replace(/\n/g, " ").trim();
@@ -38,6 +40,12 @@ async function main(): Promise<void> {
   console.log("[max] Creating orchestrator session...");
   await initOrchestrator(client);
   console.log("[max] Orchestrator session ready");
+
+  // Load agent registry and initialize AgentBus
+  const agentConfigs = loadAgents();
+  console.log(`[max] Loaded ${agentConfigs.size} agent definition(s): ${Array.from(agentConfigs.keys()).join(", ") || "(none)"}`);
+  initAgentBus(client);
+  console.log("[max] AgentBus initialized (agents spawn lazily on first use)");
 
   // Wire up proactive notifications — route to the originating channel
   setProactiveNotify((text, channel) => {
@@ -117,6 +125,9 @@ async function shutdown(): Promise<void> {
     try { await stopBot(); } catch { /* best effort */ }
   }
 
+  // Destroy all specialist agent sessions
+  try { await shutdownAgentBus(); } catch { /* best effort */ }
+
   // Destroy all active worker sessions to free memory
   await Promise.allSettled(
     Array.from(workers.values()).map((w) => w.session.destroy())
@@ -143,6 +154,9 @@ export async function restartDaemon(): Promise<void> {
     await sendProactiveMessage("Restarting — back in a sec ⏳").catch(() => {});
     try { await stopBot(); } catch { /* best effort */ }
   }
+
+  // Destroy all specialist agent sessions
+  try { await shutdownAgentBus(); } catch { /* best effort */ }
 
   // Destroy all active worker sessions to free memory
   await Promise.allSettled(

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -23,6 +23,9 @@ export const HISTORY_PATH = join(MAX_HOME, "tui_history");
 /** Path to optional TUI debug log */
 export const TUI_DEBUG_LOG_PATH = join(MAX_HOME, "tui-debug.log");
 
+/** Path to user-local agent definitions (~/.max/agents/) */
+export const AGENTS_DIR = join(MAX_HOME, "agents");
+
 /** Path to the API bearer token file */
 export const API_TOKEN_PATH = join(MAX_HOME, "api-token");
 

--- a/src/store/db.ts
+++ b/src/store/db.ts
@@ -43,6 +43,7 @@ export function getDb(): Database.Database {
         category TEXT NOT NULL CHECK(category IN ('preference', 'fact', 'project', 'person', 'routine')),
         content TEXT NOT NULL,
         source TEXT NOT NULL DEFAULT 'user',
+        namespace TEXT NOT NULL DEFAULT 'global',
         created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
         last_accessed DATETIME DEFAULT CURRENT_TIMESTAMP
       )
@@ -68,6 +69,27 @@ export function getDb(): Database.Database {
     }
     // Prune conversation log at startup — keep more history for better recovery
     db.prepare(`DELETE FROM conversation_log WHERE id NOT IN (SELECT id FROM conversation_log ORDER BY id DESC LIMIT 1000)`).run();
+
+    // Migrate: add namespace column to memories if it doesn't exist
+    try {
+      db.prepare(`SELECT namespace FROM memories LIMIT 1`).get();
+    } catch {
+      db.exec(`ALTER TABLE memories ADD COLUMN namespace TEXT NOT NULL DEFAULT 'global'`);
+    }
+    // Ensure index exists for namespace queries
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_memories_namespace ON memories(namespace)`);
+
+    // Agent sessions table — tracks persistent specialist Copilot sessions
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS agent_sessions (
+        slug TEXT PRIMARY KEY,
+        copilot_session_id TEXT NOT NULL,
+        model TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'idle',
+        last_active DATETIME DEFAULT CURRENT_TIMESTAMP,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+      )
+    `);
 
     // Set up FTS5 for memory search (graceful fallback if not available)
     try {
@@ -434,6 +456,37 @@ export function runMemoryMaintenance(): { deduped: number; pruned: number; cappe
   const pruned = pruneStaleMemories();
   const capped = capAutoMemories();
   return { deduped, pruned, capped };
+}
+
+// ---------------------------------------------------------------------------
+// Agent session persistence
+// ---------------------------------------------------------------------------
+
+export function saveAgentSession(slug: string, sessionId: string, model: string): void {
+  const db = getDb();
+  db.prepare(
+    `INSERT OR REPLACE INTO agent_sessions (slug, copilot_session_id, model, status, last_active) VALUES (?, ?, ?, 'idle', CURRENT_TIMESTAMP)`
+  ).run(slug, sessionId, model);
+}
+
+export function getAgentSession(slug: string): { copilot_session_id: string; model: string; status: string } | undefined {
+  const db = getDb();
+  return db.prepare(`SELECT copilot_session_id, model, status FROM agent_sessions WHERE slug = ?`).get(slug) as { copilot_session_id: string; model: string; status: string } | undefined;
+}
+
+export function updateAgentSessionStatus(slug: string, status: string): void {
+  const db = getDb();
+  db.prepare(`UPDATE agent_sessions SET status = ?, last_active = CURRENT_TIMESTAMP WHERE slug = ?`).run(status, slug);
+}
+
+export function deleteAgentSession(slug: string): void {
+  const db = getDb();
+  db.prepare(`DELETE FROM agent_sessions WHERE slug = ?`).run(slug);
+}
+
+export function listAgentSessions(): { slug: string; copilot_session_id: string; model: string; status: string; last_active: string }[] {
+  const db = getDb();
+  return db.prepare(`SELECT slug, copilot_session_id, model, status, last_active FROM agent_sessions`).all() as { slug: string; copilot_session_id: string; model: string; status: string; last_active: string }[];
 }
 
 export function closeDb(): void {

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -6,6 +6,9 @@ import { searchMemories } from "../store/db.js";
 import { listSkills } from "../copilot/skills.js";
 import { restartDaemon } from "../daemon.js";
 import { getRouterConfig, updateRouterConfig } from "../copilot/router.js";
+import { getStickyAgent, getAllStickyAgents } from "../agents/mentions.js";
+import { getAgent, listAgents } from "../agents/registry.js";
+import { getAllAgentStatuses } from "../agents/bus.js";
 import { tmpdir } from "os";
 import { join } from "path";
 import { writeFile, unlink } from "fs/promises";
@@ -97,9 +100,12 @@ export function createBot(): Bot {
   bot.command("help", (ctx) =>
     ctx.reply(
       "I'm Max, your AI daemon.\n\n" +
-        "Just send me a message and I'll handle it.\n\n" +
+        "Just send me a message and I'll handle it.\n" +
+        "Use @agent to talk to a specialist (e.g. @designer, @coder).\n" +
+        "Use @max to return to me.\n\n" +
         "Commands:\n" +
         "/cancel — Cancel the current message\n" +
+        "/agent — Show current specialist / list agents\n" +
         "/model — Show current model\n" +
         "/model <name> — Switch model\n" +
         "/models — List all available models\n" +
@@ -204,6 +210,33 @@ export function createBot(): Bot {
       ? "⚡ Auto mode on"
       : `Auto mode off · using ${config.copilotModel}`;
     await ctx.reply(label);
+  });
+
+  bot.command("agent", async (ctx) => {
+    const sticky = getStickyAgent("telegram");
+    if (sticky) {
+      const agentConfig = getAgent(sticky);
+      const label = agentConfig
+        ? `${agentConfig.emoji} Currently talking to **${agentConfig.name}** (@${sticky})`
+        : `Currently talking to @${sticky}`;
+      await ctx.reply(label + "\n\nUse @max to return to Max.");
+    } else {
+      const agents = listAgents();
+      if (agents.length === 0) {
+        await ctx.reply("Talking to Max (no specialists configured).");
+      } else {
+        const statuses = getAllAgentStatuses();
+        const lines = statuses.map((s) => {
+          const statusIcon = s.status === "running" ? "🔄" : s.status === "idle" ? "💤" : s.status === "error" ? "❌" : "⬜";
+          return `${s.emoji} ${s.name} (@${s.slug}) ${statusIcon} ${s.status}`;
+        });
+        await ctx.reply(
+          "Talking to Max.\n\n" +
+          "Specialists:\n" + lines.join("\n") +
+          "\n\nUse @agent to talk to a specialist."
+        );
+      }
+    }
   });
 
   // Handle all text messages


### PR DESCRIPTION
## Summary

Implements the Persistent Specialist Agent Team architecture from #12.

Max stays as the orchestrator/router while persistent specialist agents handle domain-specific tasks with scoped memory, lazy spawning, and direct @mention routing.

### New modules (`src/agents/`)
- **registry.ts** — Loads `AGENT.md` configs (YAML frontmatter + markdown system prompt)
- **bus.ts** — AgentBus: lazy spawn, dispatch with per-agent mutex, chaining, idle cleanup
- **mentions.ts** — `@agent` parser + sticky sessions per channel
- **memory.ts** — Namespace-scoped memory wrappers

### Built-in specialists (`agents/`)
| Agent | Slug | Model | Domain |
|---|---|---|---|
| 🎨 Designer | `@designer` | claude-opus-4.6 | UI/UX, CSS, layout |
| 💻 Coder | `@coder` | claude-sonnet-4.6 | Engineering, debugging |
| 🔍 Researcher | `@researcher` | claude-sonnet-4.6 | Analysis, fact-checking |
| ⚖️ Legal | `@legal` | claude-opus-4.6 | Contracts, compliance |

### Key features
- **Lazy spawning**: Agents start on first use, not at boot
- **Per-agent mutex**: Serializes dispatch to prevent session races
- **Idle cleanup**: Evicts agents after configurable timeout (default 60min)
- **Session persistence**: `agent_sessions` table enables resume across restarts
- **@mention routing**: `@designer help me with this layout` routes directly to Designer
- **Sticky sessions**: `@designer` sets channel to Designer until `@max`
- **Agent chaining**: Legal drafts → Designer formats → Max delivers
- **Namespace-scoped memory**: Context doesn't bleed across domains
- **New tools**: `delegate_to_agent`, `chain_agents`, `check_agent_status`
- **Telegram**: `/agent` command shows current specialist and statuses

### Schema changes
- `memories` table: added `namespace` column (default `'global'`)
- New `agent_sessions` table for session persistence

### Config
- `MAX_CONCURRENT_AGENTS` (default 5)
- `AGENT_IDLE_TIMEOUT` (default 3600000ms / 60min)

### Verification
- TypeScript build passes (`tsc` exit 0)
- Adversarial review: concurrency race fixed (per-agent mutex), destroy race fixed, env var validation added, mention regex expanded for hyphens

Closes #12