### PR TITLE
fix: Windows path separator bug in agent/skill path guards (v1.5.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to Max are documented here.
 
+## [1.5.2] — 2026-04-24
+
+### Bug fixes
+- Fix `hire_agent` and skill create/remove broken on Windows due to hardcoded `/` path separator in traversal guards — now uses `path.sep`.
+
+---
+
 ## [1.5.0] — 2026-04-22
 
 ### Multi-agent system

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "heymax",
-  "version": "1.5.0",
+  "version": "1.5.2",
   "description": "Max — a personal AI assistant for developers, built on the GitHub Copilot SDK",
   "bin": {
     "max": "dist/cli.js"

--- a/src/copilot/agents.ts
+++ b/src/copilot/agents.ts
@@ -1,6 +1,6 @@
 import { readdirSync, readFileSync, mkdirSync, writeFileSync, existsSync, rmSync, copyFileSync } from "fs";
 import { createHash } from "crypto";
-import { join, dirname } from "path";
+import { join, dirname, sep } from "path";
 import { fileURLToPath } from "url";
 import { z } from "zod";
 import { approveAll, type CopilotClient, type CopilotSession, type Tool } from "@github/copilot-sdk";
@@ -223,7 +223,7 @@ export function createAgentFile(
     return `Invalid slug '${slug}': must be kebab-case (a-z0-9 with hyphens).`;
   }
   const filePath = join(AGENTS_DIR, `${slug}.agent.md`);
-  if (!filePath.startsWith(AGENTS_DIR + "/")) {
+  if (!filePath.startsWith(AGENTS_DIR + sep)) {
     return `Invalid slug '${slug}': path traversal detected.`;
   }
   if (existsSync(filePath)) {
@@ -252,7 +252,7 @@ export function removeAgentFile(slug: string): string | null {
     return `Cannot remove built-in agent '${slug}'. You can edit its file instead.`;
   }
   const filePath = join(AGENTS_DIR, `${slug}.agent.md`);
-  if (!filePath.startsWith(AGENTS_DIR + "/")) {
+  if (!filePath.startsWith(AGENTS_DIR + sep)) {
     return `Invalid slug '${slug}': path traversal detected.`;
   }
   if (!existsSync(filePath)) {

--- a/src/copilot/skills.ts
+++ b/src/copilot/skills.ts
@@ -1,5 +1,5 @@
 import { readdirSync, readFileSync, mkdirSync, writeFileSync, existsSync, rmSync } from "fs";
-import { join, dirname } from "path";
+import { join, dirname, sep } from "path";
 import { homedir } from "os";
 import { fileURLToPath } from "url";
 import { SKILLS_DIR } from "../paths.js";
@@ -87,7 +87,7 @@ export function listSkills(): SkillInfo[] {
 export function createSkill(slug: string, name: string, description: string, instructions: string): string {
   const skillDir = join(LOCAL_SKILLS_DIR, slug);
   // Guard against path traversal
-  if (!skillDir.startsWith(LOCAL_SKILLS_DIR + "/")) {
+  if (!skillDir.startsWith(LOCAL_SKILLS_DIR + sep)) {
     return `Invalid slug '${slug}': must be a simple kebab-case name without path separators.`;
   }
   if (existsSync(skillDir)) {
@@ -117,7 +117,7 @@ ${instructions}
 export function removeSkill(slug: string): { ok: boolean; message: string } {
   const skillDir = join(LOCAL_SKILLS_DIR, slug);
   // Guard against path traversal
-  if (!skillDir.startsWith(LOCAL_SKILLS_DIR + "/")) {
+  if (!skillDir.startsWith(LOCAL_SKILLS_DIR + sep)) {
     return { ok: false, message: `Invalid slug '${slug}': must be a simple kebab-case name without path separators.` };
   }
   if (!existsSync(skillDir)) {


### PR DESCRIPTION
## Summary

Fixes `hire_agent`, `removeAgentFile`, `createSkill`, and `removeSkill` being broken on Windows due to hardcoded `"/"` in path traversal guards.

On Windows, `path.join()` produces backslash separators (`\`), so the check `path.startsWith(DIR + "/")` always fails — causing every agent hire and skill creation to be rejected as "path traversal detected".

## Changes

- **`src/copilot/agents.ts`** — Replace `AGENTS_DIR + "/"` with `AGENTS_DIR + sep` (2 locations)
- **`src/copilot/skills.ts`** — Replace `LOCAL_SKILLS_DIR + "/"` with `LOCAL_SKILLS_DIR + sep` (2 locations)

Bumps version to **1.5.2**.