### PR TITLE
feat: add Feishu/Lark messaging channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Max
 
-AI orchestrator powered by [Copilot SDK](https://github.com/github/copilot-sdk) — control multiple Copilot CLI sessions from Telegram or a local terminal.
+AI orchestrator powered by [Copilot SDK](https://github.com/github/copilot-sdk) — control multiple Copilot CLI sessions from Telegram, Feishu, or a local terminal.
 
 ## Highlights
 
@@ -40,7 +40,7 @@ Or manually: `npm install -g heymax@latest`. Your `~/.max/` config carries forwa
 max setup
 ```
 
-This creates `~/.max/` and walks you through configuration (Telegram bot token, etc.). Telegram is optional — you can use Max with just the terminal UI.
+This creates `~/.max/` and walks you through configuration (Telegram bot token, Feishu app credentials, etc.). All chat channels are optional — you can use Max with just the terminal UI.
 
 ### 2. Make sure Copilot CLI is authenticated
 
@@ -54,9 +54,11 @@ copilot login
 max start
 ```
 
-### 4. Connect via terminal
+### 4. Connect from chat or terminal
 
-In a separate terminal:
+If you configured Telegram or Feishu/Lark during setup, start by messaging your bot there.
+
+Or connect via terminal in a separate shell:
 
 ```bash
 max tui
@@ -64,7 +66,7 @@ max tui
 
 ### 5. Talk to Max
 
-From Telegram or the TUI, just send natural language:
+From Telegram, Feishu/Lark, or the TUI, just send natural language:
 
 - "Start working on the auth bug in ~/dev/myapp"
 - "What sessions are running?"
@@ -111,6 +113,7 @@ Max runs a persistent **orchestrator Copilot session** — an always-on AI brain
 
 You can talk to Max from:
 - **Telegram** — remote access from your phone (authenticated by user ID)
+- **Feishu / Lark** — same as Telegram, for users in mainland China (authenticated by `open_id`)
 - **TUI** — local terminal client (no auth needed)
 
 ### Memory
@@ -127,15 +130,16 @@ Max maintains a **personal wiki** at `~/.max/wiki/` instead of a flat list of me
 ## Architecture
 
 ```
-Telegram ──→ Max Daemon ←── TUI
-                │
-          Orchestrator Session (Copilot SDK)
-                │
-      ┌─────────┼─────────┐
-   Worker 1  Worker 2  Worker N
+Telegram ─┐
+Feishu ───┼──→ Max Daemon ←── TUI
+                   │         │
+                   └─ chat   Orchestrator Session (Copilot SDK)
+                                                  │
+                               ┌─────────┼─────────┐
+                         Worker 1  Worker 2  Worker N
 ```
 
-- **Daemon** (`max start`) — persistent service running Copilot SDK + Telegram bot + HTTP API
+- **Daemon** (`max start`) — persistent service running Copilot SDK + Telegram bot + Feishu/Lark bot + HTTP API
 - **TUI** (`max tui`) — lightweight terminal client connecting to the daemon
 - **Orchestrator** — long-running Copilot session with custom tools for session management
 - **Workers** — child Copilot sessions for specific coding tasks

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "type": "module",
   "dependencies": {
     "@github/copilot-sdk": "^0.2.2",
+    "@larksuiteoapi/node-sdk": "^1.49.0",
     "better-sqlite3": "^12.6.2",
     "dotenv": "^17.3.1",
     "express": "^5.2.1",

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -135,11 +135,18 @@ app.post("/message", (req: Request, res: Response) => {
   res.json({ status: "queued" });
 });
 
-// Cancel the current in-flight message
-app.post("/cancel", async (_req: Request, res: Response) => {
-  const cancelled = await cancelCurrentMessage();
-  // Notify all SSE clients that the message was cancelled
-  for (const [, sseRes] of sseClients) {
+// Cancel the current in-flight message for a specific TUI connection.
+app.post("/cancel", async (req: Request, res: Response) => {
+  const { connectionId } = req.body as { connectionId?: string };
+
+  if (!connectionId || !sseClients.has(connectionId)) {
+    res.status(400).json({ error: "Missing or invalid 'connectionId'. Connect to /stream first." });
+    return;
+  }
+
+  const cancelled = await cancelCurrentMessage(`tui:${connectionId}`);
+  const sseRes = sseClients.get(connectionId);
+  if (sseRes) {
     sseRes.write(
       `data: ${JSON.stringify({ type: "cancelled" })}\n\n`
     );
@@ -312,4 +319,12 @@ export function broadcastToSSE(text: string): void {
       `data: ${JSON.stringify({ type: "message", content: text })}\n\n`
     );
   }
+}
+
+export function sendToSSEConnection(connectionId: string, text: string): void {
+  const res = sseClients.get(connectionId);
+  if (!res) return;
+  res.write(
+    `data: ${JSON.stringify({ type: "message", content: text })}\n\n`
+  );
 }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,0 +1,112 @@
+// Channel-agnostic implementations of the slash commands shared by chat
+// transports that don't have a richer per-channel UX (currently Feishu).
+// The Telegram bot keeps its own command handlers because it has bespoke
+// features (image replies, /models with chunking, /agents helpers, etc.).
+
+import { config, persistModel } from "./config.js";
+import { listSkills } from "./copilot/skills.js";
+import {
+  cancelCurrentMessage,
+  getAgentInfo,
+} from "./copilot/orchestrator.js";
+import { getRouterConfig, updateRouterConfig } from "./copilot/router.js";
+import { ensureWikiStructure } from "./wiki/fs.js";
+import { parseIndex } from "./wiki/index-manager.js";
+
+export const HELP_TEXT =
+  "I'm Max, your AI daemon.\n\n" +
+  "Just send me a message and I'll handle it.\n\n" +
+  "Commands:\n" +
+  "/cancel — Cancel the current message\n" +
+  "/model — Show current model\n" +
+  "/model <name> — Switch model\n" +
+  "/models — List available models\n" +
+  "/auto — Toggle auto model routing\n" +
+  "/memory — Show wiki pages\n" +
+  "/skills — List installed skills\n" +
+  "/agents — List running agents\n" +
+  "/workers — Alias for /agents\n" +
+  "/restart — Restart Max\n" +
+  "/help — Show this help";
+
+export const START_TEXT = "Max is online. Send me anything.";
+
+export async function handleCancel(sourceKey?: string): Promise<string> {
+  const cancelled = await cancelCurrentMessage(sourceKey);
+  return cancelled ? "⛔ Cancelled." : "Nothing to cancel.";
+}
+
+export async function handleModel(arg: string | undefined): Promise<string> {
+  const trimmed = arg?.trim();
+  if (!trimmed) {
+    return `Current model: ${config.copilotModel}`;
+  }
+  // Validate against available models before persisting
+  try {
+    const { getClient } = await import("./copilot/client.js");
+    const client = await getClient();
+    const models = await client.listModels();
+    const match = models.find((m) => m.id === trimmed);
+    if (!match) {
+      const suggestions = models
+        .filter((m) => m.id.includes(trimmed) || m.id.toLowerCase().includes(trimmed.toLowerCase()))
+        .map((m) => m.id);
+      const hint = suggestions.length > 0 ? ` Did you mean: ${suggestions.join(", ")}?` : "";
+      return `Model '${trimmed}' not found.${hint}`;
+    }
+  } catch {
+    // If validation fails (client not ready), allow the switch — will fail on next message if wrong
+  }
+  const previous = config.copilotModel;
+  config.copilotModel = trimmed;
+  persistModel(trimmed);
+  return `Model: ${previous} → ${trimmed}`;
+}
+
+export async function handleModels(): Promise<string> {
+  try {
+    const { getClient } = await import("./copilot/client.js");
+    const client = await getClient();
+    const models = await client.listModels();
+    if (models.length === 0) {
+      return "No models available.";
+    }
+    return models
+      .map((m) => (m.id === config.copilotModel ? `• ${m.id} ← current` : `• ${m.id}`))
+      .join("\n");
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return `Failed to list models: ${msg}`;
+  }
+}
+
+export function handleMemory(): string {
+  ensureWikiStructure();
+  const entries = parseIndex();
+  if (entries.length === 0) return "No wiki pages yet.";
+  const lines = entries.map((e) => {
+    let line = `• ${e.title}: ${e.summary}`;
+    if (e.updated) line += ` (${e.updated})`;
+    return line;
+  });
+  return lines.join("\n") + `\n\n${entries.length} wiki pages total`;
+}
+
+export function handleSkills(): string {
+  const skills = listSkills();
+  if (skills.length === 0) return "No skills installed.";
+  return skills.map((s) => `• ${s.name} (${s.source}) — ${s.description}`).join("\n");
+}
+
+export function handleAgents(): string {
+  const workers = getAgentInfo();
+  if (workers.length === 0) return "No workers running.";
+  return workers.map((w) => `🟢 @${w.slug} (${w.model}) — ${w.description}`).join("\n");
+}
+
+export function handleAuto(): string {
+  const current = getRouterConfig();
+  const newState = !current.enabled;
+  updateRouterConfig({ enabled: newState });
+  return newState ? "⚡ Auto mode on" : `Auto mode off · using ${config.copilotModel}`;
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,6 +13,10 @@ const configSchema = z.object({
   API_PORT: z.string().optional(),
   COPILOT_MODEL: z.string().optional(),
   WORKER_TIMEOUT: z.string().optional(),
+  FEISHU_APP_ID: z.string().min(1).optional(),
+  FEISHU_APP_SECRET: z.string().min(1).optional(),
+  FEISHU_AUTHORIZED_OPEN_ID: z.string().min(1).optional(),
+  FEISHU_DOMAIN: z.enum(["feishu", "lark"]).optional(),
 });
 
 const raw = configSchema.parse(process.env);
@@ -47,6 +51,10 @@ export const config = {
   authorizedUserId: parsedUserId,
   apiPort: parsedPort,
   workerTimeoutMs: parsedWorkerTimeout,
+  feishuAppId: raw.FEISHU_APP_ID,
+  feishuAppSecret: raw.FEISHU_APP_SECRET,
+  feishuAuthorizedOpenId: raw.FEISHU_AUTHORIZED_OPEN_ID,
+  feishuDomain: raw.FEISHU_DOMAIN ?? "feishu",
   get copilotModel(): string {
     return _copilotModel;
   },
@@ -55,6 +63,9 @@ export const config = {
   },
   get telegramEnabled(): boolean {
     return !!this.telegramBotToken && this.authorizedUserId !== undefined;
+  },
+  get feishuEnabled(): boolean {
+    return !!this.feishuAppId && !!this.feishuAppSecret && !!this.feishuAuthorizedOpenId;
   },
   get selfEditEnabled(): boolean {
     return process.env.MAX_SELF_EDIT === "1";

--- a/src/copilot/orchestrator.ts
+++ b/src/copilot/orchestrator.ts
@@ -29,9 +29,12 @@ const HEALTH_CHECK_INTERVAL_MS = 30_000;
 
 const ORCHESTRATOR_SESSION_KEY = "orchestrator_session_id";
 
+export type SourceChannel = "telegram" | "tui" | "feishu";
+
 export type MessageSource =
   | { type: "telegram"; chatId: number; messageId: number }
   | { type: "tui"; connectionId: string }
+  | { type: "feishu"; chatId: string; messageId: string; openId: string }
   | { type: "background" };
 
 export type MessageCallback = (text: string, done: boolean) => void;
@@ -43,8 +46,8 @@ export function setMessageLogger(fn: LogFn): void {
   logMessage = fn;
 }
 
-// Proactive notification — sends unsolicited messages to the user on a specific channel
-type ProactiveNotifyFn = (text: string, channel?: "telegram" | "tui") => void;
+// Proactive notification — sends unsolicited messages to the user on a specific destination.
+type ProactiveNotifyFn = (text: string, destination?: string) => void;
 let proactiveNotifyFn: ProactiveNotifyFn | undefined;
 
 export function setProactiveNotify(fn: ProactiveNotifyFn): void {
@@ -73,7 +76,7 @@ type QueuedMessage = {
   prompt: string;
   attachments?: Array<{ type: "file"; path: string; displayName?: string }>;
   callback: MessageCallback;
-  sourceChannel?: "telegram" | "tui";
+  sourceChannel?: SourceChannel;
   /** Target agent slug for @mention routing. If undefined, goes to orchestrator. */
   targetAgent?: string;
   /** Conversation channel key for sticky routing, e.g. "telegram:123" or "tui:conn-1". */
@@ -85,11 +88,30 @@ const messageQueue: QueuedMessage[] = [];
 let processing = false;
 let currentCallback: MessageCallback | undefined;
 /** The channel currently being processed — tools use this to tag new workers. */
-let currentSourceChannel: "telegram" | "tui" | undefined;
+let currentSourceChannel: SourceChannel | undefined;
+/** The exact source currently being processed — used for scoped cancel/result delivery. */
+let currentSourceKey: string | undefined;
 
 /** Get the channel that originated the message currently being processed. */
-export function getCurrentSourceChannel(): "telegram" | "tui" | undefined {
+export function getCurrentSourceChannel(): SourceChannel | undefined {
   return currentSourceChannel;
+}
+
+export function getCurrentSourceKey(): string | undefined {
+  return currentSourceKey;
+}
+
+function getSourceKey(source: MessageSource): string | undefined {
+  switch (source.type) {
+    case "telegram":
+      return `telegram:${source.chatId}`;
+    case "tui":
+      return `tui:${source.connectionId}`;
+    case "feishu":
+      return `feishu:${source.chatId}`;
+    default:
+      return undefined;
+  }
 }
 
 function getSessionConfig() {
@@ -113,8 +135,7 @@ export function feedAgentResult(taskId: string, agentSlug: string, result: strin
         // Route notification to the task's origin channel
         const tasks = getActiveTasks();
         const task = tasks.find((t) => t.taskId === taskId);
-        const channel = task?.originChannel as "telegram" | "tui" | undefined;
-        proactiveNotifyFn(_text, channel);
+        proactiveNotifyFn(_text, task?.originChannel);
       }
     }
   );
@@ -369,6 +390,7 @@ async function processQueue(): Promise<void> {
   while (messageQueue.length > 0) {
     const item = messageQueue.shift()!;
     currentSourceChannel = item.sourceChannel;
+    currentSourceKey = item.channelKey;
     try {
       let result: string;
 
@@ -409,6 +431,7 @@ async function processQueue(): Promise<void> {
       item.reject(err);
     }
     currentSourceChannel = undefined;
+    currentSourceKey = undefined;
   }
 
   processing = false;
@@ -430,7 +453,8 @@ export async function sendToOrchestrator(
 ): Promise<void> {
   const sourceLabel =
     source.type === "telegram" ? "telegram" :
-    source.type === "tui" ? "tui" : "background";
+    source.type === "tui" ? "tui" :
+    source.type === "feishu" ? "feishu" : "background";
   logMessage("in", sourceLabel, prompt);
 
   // Parse @mention routing (e.g., "@coder fix the bug" → target "coder")
@@ -447,16 +471,18 @@ export async function sendToOrchestrator(
   const logRole = source.type === "background" ? "system" : "user";
 
   // Determine the source channel for agent origin tracking
-  const sourceChannel: "telegram" | "tui" | undefined =
+  const sourceChannel: SourceChannel | undefined =
     source.type === "telegram" ? "telegram" :
-    source.type === "tui" ? "tui" : undefined;
+    source.type === "tui" ? "tui" :
+    source.type === "feishu" ? "feishu" : undefined;
+  const channelKey = getSourceKey(source);
 
   // Enqueue and process
   void (async () => {
     for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
       try {
         const finalContent = await new Promise<string>((resolve, reject) => {
-          messageQueue.push({ prompt: taggedPrompt, attachments, callback, sourceChannel, targetAgent, resolve, reject });
+          messageQueue.push({ prompt: taggedPrompt, attachments, callback, sourceChannel, targetAgent, channelKey, resolve, reject });
           processQueue();
         });
         // Deliver response to user FIRST, then log best-effort
@@ -491,17 +517,19 @@ export async function sendToOrchestrator(
   })();
 }
 
-/** Cancel the in-flight message and drain the queue. */
-export async function cancelCurrentMessage(): Promise<boolean> {
-  // Drain any queued messages
-  const drained = messageQueue.length;
-  while (messageQueue.length > 0) {
-    const item = messageQueue.shift()!;
+/** Cancel the in-flight message and queued work for a specific source when provided. */
+export async function cancelCurrentMessage(sourceKey?: string): Promise<boolean> {
+  let drained = 0;
+  for (let i = messageQueue.length - 1; i >= 0; i--) {
+    const item = messageQueue[i];
+    if (sourceKey && item.channelKey !== sourceKey) continue;
+    messageQueue.splice(i, 1);
     item.reject(new Error("Cancelled"));
+    drained++;
   }
 
   // Abort the active session request
-  if (orchestratorSession && currentCallback) {
+  if (orchestratorSession && currentCallback && (!sourceKey || currentSourceKey === sourceKey)) {
     try {
       await orchestratorSession.abort();
       console.log(`[max] Aborted in-flight request`);

--- a/src/copilot/tools.ts
+++ b/src/copilot/tools.ts
@@ -7,7 +7,7 @@ import { homedir } from "os";
 import { listSkills, createSkill, removeSkill } from "./skills.js";
 import { config, persistModel } from "../config.js";
 import { SESSIONS_DIR } from "../paths.js";
-import { getCurrentSourceChannel, switchSessionModel } from "./orchestrator.js";
+import { getCurrentSourceKey, switchSessionModel } from "./orchestrator.js";
 import { getRouterConfig, updateRouterConfig } from "./router.js";
 import { ensureWikiStructure, readPage, writePage, deletePage, listPages, writeRawSource, listSources, getWikiDir, assertPagePath } from "../wiki/fs.js";
 import { searchIndex, addToIndex, removeFromIndex, parseIndex, buildIndexEntryForPage, type IndexEntry } from "../wiki/index-manager.js";
@@ -99,7 +99,7 @@ export function createTools(deps: ToolDeps): Tool<any>[] {
           return `Failed to create session for @${agent.slug}: ${msg}`;
         }
 
-        const task = registerTask(agent.slug, args.summary, getCurrentSourceChannel());
+        const task = registerTask(agent.slug, args.summary, getCurrentSourceKey());
 
         // Persist task to DB
         const db = getDb();

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1,7 +1,13 @@
 import { getClient, stopClient } from "./copilot/client.js";
 import { initOrchestrator, setMessageLogger, setProactiveNotify, getAgentInfo, shutdownAgents } from "./copilot/orchestrator.js";
-import { startApiServer, broadcastToSSE } from "./api/server.js";
+import { startApiServer, broadcastToSSE, sendToSSEConnection } from "./api/server.js";
 import { createBot, startBot, stopBot, sendProactiveMessage } from "./telegram/bot.js";
+import {
+  createBot as createFeishuBot,
+  startBot as startFeishuBot,
+  stopBot as stopFeishuBot,
+  sendProactiveMessage as sendFeishuProactiveMessage,
+} from "./feishu/bot.js";
 import { getDb, closeDb, getState } from "./store/db.js";
 import { config } from "./config.js";
 import { spawn } from "child_process";
@@ -105,13 +111,19 @@ async function main(): Promise<void> {
   console.log("[max] Orchestrator session ready");
 
   // Wire up proactive notifications — route to the originating channel
-  setProactiveNotify((text, channel) => {
-    console.log(`[max] bg-notify (${channel ?? "all"}) ⟵  ${truncate(text)}`);
-    if (!channel || channel === "telegram") {
+  setProactiveNotify((text, destination) => {
+    console.log(`[max] bg-notify (${destination ?? "all"}) ⟵  ${truncate(text)}`);
+    if (!destination || destination.startsWith("telegram:")) {
       if (config.telegramEnabled) sendProactiveMessage(text);
     }
-    if (!channel || channel === "tui") {
+    if (!destination || destination === "tui") {
       broadcastToSSE(text);
+    }
+    if (destination?.startsWith("tui:")) {
+      sendToSSEConnection(destination.slice(4), text);
+    }
+    if (!destination || destination.startsWith("feishu:")) {
+      if (config.feishuEnabled) sendFeishuProactiveMessage(text);
     }
   });
 
@@ -130,6 +142,16 @@ async function main(): Promise<void> {
     console.log("[max] Telegram user ID missing — skipping bot. Run 'max setup' and enter your Telegram user ID (get it from @userinfobot).");
   }
 
+  // Start Feishu bot (if configured)
+  if (config.feishuEnabled) {
+    createFeishuBot();
+    await startFeishuBot();
+  } else if (!config.feishuAppId && !config.feishuAppSecret && !config.feishuAuthorizedOpenId) {
+    console.log("[max] Feishu not configured — skipping bot. Run 'max setup' to configure.");
+  } else {
+    console.log("[max] Feishu config incomplete — skipping bot. Run 'max setup' and provide App ID, App Secret, and authorized open_id.");
+  }
+
   console.log("[max] Max is fully operational.");
 
   // Non-blocking update check
@@ -142,8 +164,13 @@ async function main(): Promise<void> {
     .catch(() => {});  // silent — network may be unavailable
 
   // Notify user if this is a restart (not a fresh start)
-  if (config.telegramEnabled && process.env.MAX_RESTARTED === "1") {
-    await sendProactiveMessage("I'm back online 🟢").catch(() => {});
+  if (process.env.MAX_RESTARTED === "1") {
+    if (config.telegramEnabled) {
+      await sendProactiveMessage("I'm back online 🟢").catch(() => {});
+    }
+    if (config.feishuEnabled) {
+      await sendFeishuProactiveMessage("I'm back online 🟢").catch(() => {});
+    }
     delete process.env.MAX_RESTARTED;
   }
 }
@@ -180,6 +207,9 @@ async function shutdown(): Promise<void> {
   if (config.telegramEnabled) {
     try { await stopBot(); } catch { /* best effort */ }
   }
+  if (config.feishuEnabled) {
+    try { await stopFeishuBot(); } catch { /* best effort */ }
+  }
 
   // Destroy all active agent sessions
   await shutdownAgents();
@@ -202,6 +232,10 @@ export async function restartDaemon(): Promise<void> {
   if (config.telegramEnabled) {
     await sendProactiveMessage("Restarting — back in a sec ⏳").catch(() => {});
     try { await stopBot(); } catch { /* best effort */ }
+  }
+  if (config.feishuEnabled) {
+    await sendFeishuProactiveMessage("Restarting — back in a sec ⏳").catch(() => {});
+    try { await stopFeishuBot(); } catch { /* best effort */ }
   }
 
   // Destroy all active agent sessions

--- a/src/feishu/bot.ts
+++ b/src/feishu/bot.ts
@@ -1,0 +1,316 @@
+import * as Lark from "@larksuiteoapi/node-sdk";
+import { config } from "../config.js";
+import { sendToOrchestrator, getLastRouteResult } from "../copilot/orchestrator.js";
+import { restartDaemon } from "../daemon.js";
+import {
+  HELP_TEXT,
+  START_TEXT,
+  handleAgents,
+  handleAuto,
+  handleCancel,
+  handleMemory,
+  handleModel,
+  handleModels,
+  handleSkills,
+} from "../commands.js";
+import { buildCardContent, buildTextContent, chunkMessage } from "./formatter.js";
+
+let client: Lark.Client | undefined;
+let wsClient: Lark.WSClient | undefined;
+let eventDispatcher: Lark.EventDispatcher | undefined;
+
+function resolveDomain(domain: "feishu" | "lark"): Lark.Domain {
+  return domain === "lark" ? Lark.Domain.Lark : Lark.Domain.Feishu;
+}
+
+/** Strip leading @mentions of any user from a Feishu message. */
+function stripMentions(text: string): string {
+  // Feishu emits mention placeholders like "@_user_1" / "@_all" interleaved
+  // with plain text. Remove all leading mention tokens plus surrounding
+  // whitespace; preserve any subsequent body verbatim.
+  return text.replace(/^(?:\s*@[_\w]+\s*)+/, "").trim();
+}
+
+/** Decode the JSON message.content payload for a text message. */
+function extractText(rawContent: string): string {
+  try {
+    const parsed = JSON.parse(rawContent) as { text?: unknown };
+    return typeof parsed.text === "string" ? parsed.text : "";
+  } catch {
+    return "";
+  }
+}
+
+type MessageReceiveEvent = {
+  sender: {
+    sender_id?: { open_id?: string; user_id?: string; union_id?: string };
+    sender_type?: string;
+  };
+  message: {
+    message_id: string;
+    chat_id: string;
+    chat_type: "p2p" | "group" | string;
+    message_type: string;
+    content: string;
+  };
+};
+
+/** Maybe-handle a slash command. Returns the reply text, or null if not a command. */
+async function maybeHandleCommand(text: string, chatIdForCommands: string): Promise<string | null> {
+  const trimmed = text.trim();
+  if (!trimmed.startsWith("/")) return null;
+
+  const [cmdRaw, ...rest] = trimmed.slice(1).split(/\s+/);
+  const cmd = cmdRaw.toLowerCase();
+  const arg = rest.join(" ");
+
+  switch (cmd) {
+    case "start":
+      return START_TEXT;
+    case "help":
+      return HELP_TEXT;
+    case "cancel":
+      return await handleCancel(`feishu:${chatIdForCommands}`);
+    case "model":
+      return await handleModel(arg);
+    case "models":
+      return await handleModels();
+    case "memory":
+      return handleMemory();
+    case "skills":
+      return handleSkills();
+    case "workers":
+    case "agents":
+      return handleAgents();
+    case "auto":
+      return handleAuto();
+    case "restart":
+      setTimeout(() => {
+        restartDaemon().catch((err) => {
+          console.error("[max] Restart failed:", err);
+        });
+      }, 500);
+      return "⏳ Restarting Max...";
+    default:
+      return null;
+  }
+}
+
+async function sendChunkedReply(
+  messageId: string,
+  chatId: string,
+  text: string
+): Promise<void> {
+  const chunks = chunkMessage(text);
+  for (const chunk of chunks) {
+    await sendReply(messageId, chatId, chunk);
+  }
+}
+
+/** Reply to a Feishu message; falls back to a direct send if reply is unavailable. */
+async function sendReply(
+  messageId: string,
+  chatId: string,
+  text: string
+): Promise<void> {
+  if (!client) return;
+  const card = buildCardContent(text);
+
+  try {
+    await client.im.message.reply({
+      path: { message_id: messageId },
+      data: { content: card, msg_type: "interactive" },
+    });
+    return;
+  } catch (err) {
+    // Fall through to direct send. Common cause: parent message withdrawn
+    // (codes 230011 / 231003) — pattern from openclaw extensions/feishu.
+    if (!isWithdrawnReplyError(err)) {
+      console.error("[max] Feishu reply failed, falling back to direct send:", err);
+    }
+  }
+
+  try {
+    await client.im.message.create({
+      params: { receive_id_type: "chat_id" },
+      data: { receive_id: chatId, content: card, msg_type: "interactive" },
+    });
+  } catch (err) {
+    // Last resort: try plain text in case the card payload is the problem.
+    try {
+      await client.im.message.create({
+        params: { receive_id_type: "chat_id" },
+        data: { receive_id: chatId, content: buildTextContent(text), msg_type: "text" },
+      });
+    } catch (err2) {
+      console.error("[max] Feishu direct send failed:", err2 ?? err);
+    }
+  }
+}
+
+function isWithdrawnReplyError(err: unknown): boolean {
+  if (typeof err !== "object" || err === null) return false;
+  const code = (err as { code?: number }).code;
+  if (code === 230011 || code === 231003) return true;
+  const response = (err as { response?: { data?: { code?: number } } }).response;
+  return response?.data?.code === 230011 || response?.data?.code === 231003;
+}
+
+export function createBot(): { client: Lark.Client; wsClient: Lark.WSClient } {
+  if (!config.feishuAppId || !config.feishuAppSecret) {
+    throw new Error(
+      "Feishu credentials are missing. Run 'max setup' and enter your Feishu App ID and App Secret."
+    );
+  }
+  if (!config.feishuAuthorizedOpenId) {
+    throw new Error(
+      "Feishu authorized open_id is missing. Run 'max setup' and enter the open_id of the user allowed to control Max."
+    );
+  }
+
+  const domain = resolveDomain(config.feishuDomain);
+
+  client = new Lark.Client({
+    appId: config.feishuAppId,
+    appSecret: config.feishuAppSecret,
+    appType: Lark.AppType.SelfBuild,
+    domain,
+  });
+
+  wsClient = new Lark.WSClient({
+    appId: config.feishuAppId,
+    appSecret: config.feishuAppSecret,
+    domain,
+    loggerLevel: Lark.LoggerLevel.warn,
+  });
+
+  const dispatcher = new Lark.EventDispatcher({}).register({
+    "im.message.receive_v1": async (data: unknown) => {
+      const event = data as MessageReceiveEvent;
+      const senderOpenId = event.sender?.sender_id?.open_id;
+
+      // Auth: only the configured user may control Max.
+      if (!senderOpenId || senderOpenId !== config.feishuAuthorizedOpenId) {
+        return;
+      }
+
+      // v1: ignore group chats entirely (matches Telegram's single-user model).
+      if (event.message.chat_type !== "p2p") {
+        return;
+      }
+
+      // v1: only handle plain text messages.
+      if (event.message.message_type !== "text") {
+        await sendChunkedReply(
+          event.message.message_id,
+          event.message.chat_id,
+          "_(Sorry — I can only read text messages right now.)_"
+        );
+        return;
+      }
+
+      const rawText = extractText(event.message.content);
+      const text = stripMentions(rawText);
+      if (!text) return;
+
+      // Slash command short-circuit.
+      const cmdReply = await maybeHandleCommand(text, event.message.chat_id);
+      if (cmdReply !== null) {
+        await sendChunkedReply(event.message.message_id, event.message.chat_id, cmdReply);
+        return;
+      }
+
+      // Otherwise, hand off to the orchestrator.
+      sendToOrchestrator(
+        text,
+        {
+          type: "feishu",
+          chatId: event.message.chat_id,
+          messageId: event.message.message_id,
+          openId: senderOpenId,
+        },
+        (responseText: string, done: boolean) => {
+          if (!done) return;
+          void (async () => {
+            const routeResult = getLastRouteResult();
+            const suffix =
+              routeResult && routeResult.routerMode === "auto"
+                ? `\n\n_⚡ auto · ${routeResult.model}_`
+                : "";
+            const final = responseText + suffix;
+            await sendChunkedReply(event.message.message_id, event.message.chat_id, final);
+          })();
+        }
+      );
+    },
+  });
+
+  // Wire up WS → dispatcher on start().
+  eventDispatcher = dispatcher;
+
+  return { client, wsClient };
+}
+
+export async function startBot(): Promise<void> {
+  if (!wsClient || !eventDispatcher) throw new Error("Feishu bot not created");
+  console.log("[max] Feishu bot starting...");
+  // WSClient.start is fire-and-forget — it manages its own reconnect loop.
+  try {
+    wsClient.start({ eventDispatcher });
+    console.log("[max] Feishu websocket loop started; waiting for incoming events");
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (/invalid|unauthorized|app_id|secret/i.test(message)) {
+      console.error(
+        "[max] ⚠️ Feishu app credentials are invalid. Run 'max setup' and re-enter your Feishu App ID and App Secret."
+      );
+    } else {
+      console.error("[max] ❌ Feishu bot failed to start:", message);
+    }
+  }
+}
+
+export async function stopBot(): Promise<void> {
+  // Lark WSClient does not expose a clean stop in all versions; best-effort.
+  const anyClient = wsClient as unknown as { stop?: () => void; close?: () => void };
+  try {
+    anyClient.stop?.();
+    anyClient.close?.();
+  } catch {
+    /* best effort */
+  }
+  wsClient = undefined;
+  client = undefined;
+  eventDispatcher = undefined;
+}
+
+/** Send an unsolicited message to the authorized Feishu user. */
+export async function sendProactiveMessage(text: string): Promise<void> {
+  if (!client || !config.feishuAuthorizedOpenId) return;
+  const chunks = chunkMessage(text);
+  for (const chunk of chunks) {
+    try {
+      await client.im.message.create({
+        params: { receive_id_type: "open_id" },
+        data: {
+          receive_id: config.feishuAuthorizedOpenId,
+          content: buildCardContent(chunk),
+          msg_type: "interactive",
+        },
+      });
+    } catch (err) {
+      try {
+        await client.im.message.create({
+          params: { receive_id_type: "open_id" },
+          data: {
+            receive_id: config.feishuAuthorizedOpenId,
+            content: buildTextContent(chunk),
+            msg_type: "text",
+          },
+        });
+      } catch (err2) {
+        console.error("[max] Feishu proactive send failed:", err2 ?? err);
+      }
+    }
+  }
+}

--- a/src/feishu/formatter.ts
+++ b/src/feishu/formatter.ts
@@ -1,0 +1,56 @@
+// Feishu has a per-message size cap; ~30 KB is safe for both text and
+// interactive-card payloads. We chunk just under that to leave room for
+// JSON wrapping.
+const FEISHU_MAX_LENGTH = 28_000;
+
+/**
+ * Split a long message into chunks that fit within Feishu's message limit.
+ * Same algorithm as the Telegram chunker — try newlines, then spaces,
+ * then a hard cut.
+ */
+export function chunkMessage(text: string): string[] {
+  if (text.length <= FEISHU_MAX_LENGTH) {
+    return [text];
+  }
+
+  const chunks: string[] = [];
+  let remaining = text;
+
+  while (remaining.length > 0) {
+    if (remaining.length <= FEISHU_MAX_LENGTH) {
+      chunks.push(remaining);
+      break;
+    }
+
+    let splitAt = remaining.lastIndexOf("\n", FEISHU_MAX_LENGTH);
+    if (splitAt < FEISHU_MAX_LENGTH * 0.3) {
+      splitAt = remaining.lastIndexOf(" ", FEISHU_MAX_LENGTH);
+    }
+    if (splitAt < FEISHU_MAX_LENGTH * 0.3) {
+      splitAt = FEISHU_MAX_LENGTH;
+    }
+
+    chunks.push(remaining.slice(0, splitAt));
+    remaining = remaining.slice(splitAt).trimStart();
+  }
+
+  return chunks;
+}
+
+/** Build a Feishu interactive-card payload (stringified JSON) from markdown. */
+export function buildCardContent(markdown: string): string {
+  return JSON.stringify({
+    config: { wide_screen_mode: true },
+    elements: [
+      {
+        tag: "markdown",
+        content: markdown,
+      },
+    ],
+  });
+}
+
+/** Build a plain text message payload (stringified JSON) for Feishu. */
+export function buildTextContent(text: string): string {
+  return JSON.stringify({ text });
+}

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -248,6 +248,89 @@ ${BOLD}╔═══════════════════════�
     console.log(`\n${DIM}  Skipping Google. You can always set it up later with: max setup${RESET}\n`);
   }
 
+  // ── Feishu Setup ────────────────────────────────
+  console.log(`${BOLD}━━━ Feishu Setup (optional) ━━━${RESET}\n`);
+  console.log(`Feishu (飞书) is the chat app available in mainland China. If you can't`);
+  console.log(`use Telegram, this lets you talk to Max from your phone instead.`);
+  console.log();
+
+  let feishuAppId = existing.FEISHU_APP_ID || "";
+  let feishuAppSecret = existing.FEISHU_APP_SECRET || "";
+  let feishuOpenId = existing.FEISHU_AUTHORIZED_OPEN_ID || "";
+  let feishuDomain = (existing.FEISHU_DOMAIN as "feishu" | "lark" | undefined) || "feishu";
+
+  const setupFeishu = await askYesNo(rl, "Would you like to set up Feishu?");
+
+  if (setupFeishu) {
+    // ── Step 1: Pick domain ──
+    console.log(`\n${BOLD}Step 1: Choose your Feishu region${RESET}\n`);
+    console.log(`  ${CYAN}1${RESET}  ${BOLD}Feishu${RESET} — mainland China (open.feishu.cn) ${DIM}(default)${RESET}`);
+    console.log(`  ${CYAN}2${RESET}  ${BOLD}Lark${RESET}   — international (open.larksuite.com)`);
+    console.log();
+    const domainInput = (await ask(rl, `  Pick a number ${DIM}(1-2, Enter for default)${RESET}: `)).trim();
+    feishuDomain = domainInput === "2" ? "lark" : "feishu";
+    const consoleUrl =
+      feishuDomain === "lark"
+        ? "https://open.larksuite.com"
+        : "https://open.feishu.cn";
+
+    // ── Step 2: Create the bot app ──
+    console.log(`\n${BOLD}Step 2: Create a self-built app${RESET}\n`);
+    console.log(`  1. Open ${CYAN}${consoleUrl}${RESET} and sign in`);
+    console.log(`  2. Go to ${BOLD}Developer Console${RESET} → ${BOLD}Create Custom App${RESET}`);
+    console.log(`  3. Under ${BOLD}Add features${RESET}, enable ${BOLD}Bot${RESET}`);
+    console.log(`  4. Under ${BOLD}Event Subscriptions${RESET}, switch transport to ${BOLD}Long connection (WebSocket)${RESET}`);
+    console.log(`  5. Subscribe to the event ${CYAN}im.message.receive_v1${RESET}`);
+    console.log(`  6. Under ${BOLD}Permissions & Scopes${RESET}, grant:`);
+    console.log(`       ${CYAN}im:message${RESET}, ${CYAN}im:message:send_as_bot${RESET}`);
+    console.log(`  7. ${BOLD}Create a version${RESET} of the app and publish it (or enable test mode)`);
+    console.log(`  8. Copy the ${BOLD}App ID${RESET} and ${BOLD}App Secret${RESET} from the ${BOLD}Credentials & Basic Info${RESET} page`);
+    console.log();
+
+    feishuAppId = await askRequired(
+      rl,
+      `  App ID${feishuAppId ? ` ${DIM}(current: ${feishuAppId.slice(0, 8)}...)${RESET}` : ""}: `
+    );
+    feishuAppSecret = await askRequired(
+      rl,
+      `  App Secret${feishuAppSecret ? ` ${DIM}(current set)${RESET}` : ""}: `
+    );
+
+    // ── Step 3: Lock down to your open_id ──
+    console.log(`\n${BOLD}Step 3: Lock down your bot${RESET}\n`);
+    console.log(`${YELLOW}  ⚠  IMPORTANT: anyone who finds your bot can DM it.${RESET}`);
+    console.log(`  Max uses your Feishu ${BOLD}open_id${RESET} to ensure only YOU can control it.`);
+    console.log();
+    console.log(`  To find your open_id:`);
+    console.log(`  1. Open ${CYAN}${consoleUrl}/document/server-docs/api-call-guide/api-explorer${RESET}`);
+    console.log(`     (Developer Console → ${BOLD}API Debugger${RESET} / ${BOLD}API Explorer${RESET})`);
+    console.log(`  2. Pick the API ${CYAN}contact.v3.user.batch_get_id${RESET}`);
+    console.log(`  3. Authorize as your app, set ${BOLD}user_id_type=open_id${RESET},`);
+    console.log(`     and pass your mobile number or email in the request body`);
+    console.log(`  4. Copy the returned ${BOLD}open_id${RESET} (looks like ${DIM}ou_abc123...${RESET})`);
+    console.log();
+    console.log(`  ${DIM}Tip: you can also see open_ids of test users under${RESET}`);
+    console.log(`  ${DIM}Developer Console → your app → Test Users.${RESET}`);
+    console.log();
+
+    while (true) {
+      const openIdInput = await askRequired(
+        rl,
+        `  Your open_id${feishuOpenId ? ` ${DIM}(current: ${feishuOpenId})${RESET}` : ""}: `
+      );
+      if (/^ou_[A-Za-z0-9]+$/.test(openIdInput.trim())) {
+        feishuOpenId = openIdInput.trim();
+        break;
+      }
+      console.log(`${YELLOW}  That doesn't look like an open_id. It should start with 'ou_'.${RESET}`);
+    }
+
+    console.log(`\n${GREEN}  ✓ Feishu locked down — only ${feishuOpenId} can control Max.${RESET}`);
+    console.log(`${DIM}    Credentials are saved now and will be verified when Max starts.${RESET}\n`);
+  } else {
+    console.log(`\n${DIM}  Skipping Feishu. You can always set it up later with: max setup${RESET}\n`);
+  }
+
   // ── Model picker ─────────────────────────────────────────
   console.log(`\n${BOLD}━━━ Default Model ━━━${RESET}\n`);
   console.log(`${DIM}Fetching available models from Copilot...${RESET}`);
@@ -272,11 +355,24 @@ ${BOLD}╔═══════════════════════�
   const apiPort = existing.API_PORT || "7777";
   const lines: string[] = [];
   if (telegramToken) lines.push(`TELEGRAM_BOT_TOKEN=${telegramToken}`);
-  if (userId) lines.push(`AUTHORIZED_USER_ID=${userId}`);
-  lines.push(`API_PORT=${apiPort}`);
+  if (userId) lines.push(`AUTHORIZED_USER_ID=${userId}`);  if (feishuAppId) lines.push(`FEISHU_APP_ID=${feishuAppId}`);
+  if (feishuAppSecret) lines.push(`FEISHU_APP_SECRET=${feishuAppSecret}`);
+  if (feishuOpenId) lines.push(`FEISHU_AUTHORIZED_OPEN_ID=${feishuOpenId}`);
+  if (feishuAppId || feishuAppSecret || feishuOpenId) lines.push(`FEISHU_DOMAIN=${feishuDomain}`);  lines.push(`API_PORT=${apiPort}`);
   lines.push(`COPILOT_MODEL=${model}`);
 
   writeFileSync(ENV_PATH, lines.join("\n") + "\n");
+
+  const chatDestinations: string[] = [];
+  if (telegramToken && userId) chatDestinations.push("Telegram");
+  if (feishuAppId && feishuAppSecret && feishuOpenId) {
+    chatDestinations.push(feishuDomain === "lark" ? "Lark" : "Feishu");
+  }
+  const chatLabel =
+    chatDestinations.length === 0 ? "Connect via terminal:" :
+    chatDestinations.length === 1 ? `Open ${chatDestinations[0]} and message your bot!` :
+    `Open ${chatDestinations.join(" or ")} and message your bot!`;
+  const chatCommand = chatDestinations.length === 0 ? "max tui" : "(message your bot in chat)";
 
   // ── Done ─────────────────────────────────────────────────
   console.log(`
@@ -291,8 +387,8 @@ ${BOLD}Get started:${RESET}
   ${CYAN}2.${RESET} Start Max:
      ${BOLD}max start${RESET}
 
-  ${CYAN}3.${RESET} ${setupTelegram ? "Open Telegram and message your bot!" : "Connect via terminal:"}
-     ${BOLD}${setupTelegram ? "(message your bot on Telegram)" : "max tui"}${RESET}
+    ${CYAN}3.${RESET} ${chatLabel}
+      ${BOLD}${chatCommand}${RESET}
 
 ${BOLD}Things to try:${RESET}
 

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -122,7 +122,7 @@ export function createBot(): Bot {
     )
   );
   bot.command("cancel", async (ctx) => {
-    const cancelled = await cancelCurrentMessage();
+    const cancelled = await cancelCurrentMessage(`telegram:${ctx.chat.id}`);
     await ctx.reply(cancelled ? "⛔ Cancelled." : "Nothing to cancel.");
   });
   bot.command("model", async (ctx) => {

--- a/src/tui/index.ts
+++ b/src/tui/index.ts
@@ -711,8 +711,21 @@ function apiDelete(path: string, cb: (data: any) => void): void {
 function sendCancel(): void {
   stopThinking("user-cancel");
   debugLog("cancel-send", { requestId: activeRequestId, isStreaming });
+  if (!connectionId) {
+    console.error(C.red("  Failed to cancel: not connected."));
+    rl.prompt();
+    return;
+  }
+  const json = JSON.stringify({ connectionId });
   const url = new URL("/cancel", API_BASE);
-  const req = http.request(url, { method: "POST", headers: authHeaders() }, (res) => {
+  const req = http.request(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Content-Length": Buffer.byteLength(json),
+      ...authHeaders(),
+    },
+  }, (res) => {
     let data = "";
     res.on("data", (chunk) => (data += chunk));
     res.on("end", () => {
@@ -727,6 +740,7 @@ function sendCancel(): void {
     console.error(C.red(`  Failed to cancel: ${err.message}`));
     rl.prompt();
   });
+  req.write(json);
   req.end();
 }
 


### PR DESCRIPTION
- Add src/feishu/bot.ts: WebSocket-based bot using @larksuiteoapi/node-sdk; handles p2p messages, slash commands, chunked replies via interactive cards, proactive message sending, and withdrawn-reply fallback
- Add src/feishu/formatter.ts: message chunker (28 KB limit) and card/text payload builders
- Add src/commands.ts: shared slash-command handler extracted from Telegram bot
- Extend config.ts with FEISHU_APP_ID, FEISHU_APP_SECRET, FEISHU_AUTHORIZED_OPEN_ID, FEISHU_DOMAIN env vars and feishuEnabled getter
- Extend orchestrator.ts MessageSource union with feishu type
- Wire Feishu bot into daemon.ts start/stop lifecycle alongside Telegram
- Add Feishu credential prompts to setup.ts interactive wizard
- Scope /cancel API endpoint to a specific SSE connectionId; add sendToSSEConnection helper in server.ts
- Add @larksuiteoapi/node-sdk dependency in package.json
- Update README.md to document Feishu/Lark as a supported channel